### PR TITLE
View button added to documents page

### DIFF
--- a/src/apiClient/index.ts
+++ b/src/apiClient/index.ts
@@ -229,6 +229,18 @@ export const getDocumentDownloadUrl = async (documentPath: string): Promise<stri
   return data.data.signedUrl;
 };
 
+export const getDocumentViewUrl = async (documentPath: string): Promise<string> => {
+  const data = await supabase.storage
+    .from("documents")
+    .createSignedUrl(documentPath, 60 * 60);
+
+    if (data.error) {
+      throw new Error(`Failed to fetch document view URL: ${data.error.message}`);
+    }
+
+  return data.data.signedUrl;
+};
+
 export const fetchStreetsByZip = async (zip: string): Promise<string[]> => {
   const res = await fetch(
     `https://openplzapi.org/de/Streets?postalCode=${zip}`

--- a/src/components/Admin/Docs/DokumenteLayout/DokumenteLayout.tsx
+++ b/src/components/Admin/Docs/DokumenteLayout/DokumenteLayout.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import Image from "next/image";
 import { Exo_2 } from "next/font/google";
 import { useDialogStore } from "@/store/useDIalogStore";
-import { Trash2 } from "lucide-react";
+import { Trash2, Eye } from "lucide-react";
 
 const exo2 = Exo_2({ subsets: ["latin"] });
 
@@ -52,6 +52,7 @@ export default function DokumenteLayout({ userId, objektsWithLocals, documents: 
   const {
     getDocumentFileSize,
     getDownloadUrl,
+    getViewUrl,
   } = useDocumentService();
   
   const { setItemID, openDialog } = useDialogStore();
@@ -59,6 +60,15 @@ export default function DokumenteLayout({ userId, objektsWithLocals, documents: 
   const handleDeleteClick = (documentId: string) => {
     setItemID(documentId);
     openDialog("document_delete");
+  };
+
+  const handleViewClick = async (document: DocumentMetadata) => {
+    const viewUrl = await getViewUrl(document.document_url);
+    if (viewUrl) {
+      window.open(viewUrl, '_blank');
+    } else {
+      toast.error("Fehler beim Öffnen des Dokuments");
+    }
   };
   
   const documents = serverDocuments;
@@ -233,13 +243,22 @@ export default function DokumenteLayout({ userId, objektsWithLocals, documents: 
                     {fileSizes[document.id] || '--'}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <button
-                      onClick={() => handleDeleteClick(document.id)}
-                      className="p-1.5 text-dark_green hover:bg-green/20 transition-all duration-300 rounded-md"
-                      title="Dokument löschen"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleViewClick(document)}
+                        className="p-1.5 text-dark_green hover:bg-green/20 transition-all duration-300 rounded-md"
+                        title="Dokument anzeigen"
+                      >
+                        <Eye className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => handleDeleteClick(document.id)}
+                        className="p-1.5 text-dark_green hover:bg-green/20 transition-all duration-300 rounded-md"
+                        title="Dokument löschen"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/hooks/useDocumentService.ts
+++ b/src/hooks/useDocumentService.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { DocumentService, DocumentMetadata } from "@/services/documentService";
-import { getDocumentDownloadUrl } from "@/apiClient";
+import { getDocumentDownloadUrl, getDocumentViewUrl } from "@/apiClient";
 import { toast } from "sonner";
 
 export type { DocumentMetadata } from "@/services/documentService";
@@ -59,6 +59,15 @@ export const useDocumentService = () => {
     }
   }, []);
 
+  const getViewUrl = useCallback(async (documentPath: string): Promise<string | null> => {
+    try {
+      return await getDocumentViewUrl(documentPath);
+    } catch (error) {
+      console.error("Error getting view URL:", error);
+      return null;
+    }
+  }, []);
+
   const getDocumentFileSize = useCallback(async (documentPath: string): Promise<string> => {
     try {
       return await DocumentService.getDocumentFileSize(documentPath);
@@ -75,6 +84,7 @@ export const useDocumentService = () => {
     fetchDocumentsByType,
     refreshDocuments,
     getDownloadUrl,
+    getViewUrl,
     getDocumentFileSize,
   };
 };


### PR DESCRIPTION
- Add getDocumentViewUrl function to apiClient
- Add getViewUrl to useDocumentService hook
- Add Eye icon button in DokumenteLayout
- Opens documents in new browser tab for preview
- Shows error toast if view fails

Tested and working:
- View button appears on all documents
- Documents open in new tab