### PR TITLE
fix: Initialize energy_sources field with FernwÃ¤rme default value

### DIFF
--- a/src/app/(service)/fragebogen/page.tsx
+++ b/src/app/(service)/fragebogen/page.tsx
@@ -89,7 +89,7 @@ export default function FragebogenPage() {
       heating_available: null,
       central_water_supply: null,
       central_heating_system: null,
-      energy_sources: "",
+      energy_sources: "Fernwärme",
       form_confirm: false,
     },
   });

--- a/src/store/useQuestionareStore.tsx
+++ b/src/store/useQuestionareStore.tsx
@@ -30,7 +30,7 @@ export const useQuestionareStore = create<QuestionareStoreType>((set, get) => ({
 		email: "",
 		first_name: "",
 		last_name: "",
-		energy_sources: "",
+		energy_sources: "Fernwärme",
 		heating_costs: null,
 		central_water_supply: null,
 		heating_available: null,


### PR DESCRIPTION
- Changed energy_sources default from empty string to 'FernwÃ¤rme'
- Fixes form submission issue when leaving default value unchanged
- User can now submit form without manually selecting energy source