### PR TITLE
feat: integrate contact form with unified Make.com webhook

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,30 +1,22 @@
 import { NextResponse } from "next/server";
+import { sendWebhookEvent } from "@/utils/webhooks";
 
 export async function POST(req: Request) {
     try {
         const { name, email, message } = await req.json();
 
-        const url = process.env.MAKE_CONTACT_URL as string;
-
-        const response = await fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                full_name: name,
-                email,
-                message,
-            }),
+        // ✅ NEW: Use unified webhook with event_type 'contactform'
+        // Send contact form data to Denis's Make.com workflow
+        await sendWebhookEvent('contactform' as any, email, {
+            first_name: name,
+            message: message,
         });
 
-        if (!response.ok) {
-            return NextResponse.json(
-                { error: "Fehler beim Senden der Nachricht." },
-                { status: 500 }
-            );
-        }
+        console.log(`[CONTACT] Sent contact form event for ${email}`);
 
         return NextResponse.json({ success: true });
     } catch (error) {
+        console.error('[CONTACT] Error sending webhook:', error);
         return NextResponse.json(
             { error: "Serverfehler. Bitte erneut versuchen." },
             { status: 500 }

--- a/src/utils/webhooks.ts
+++ b/src/utils/webhooks.ts
@@ -5,7 +5,7 @@
 
 const MAKE_WEBHOOK_URL = 'https://hook.eu2.make.com/rfagboxirpwkbck0wkax3qh9nqum12g1';
 
-type EventType = 'login' | 'registration' | 'newsletter' | 'pwrecovery' | 'newinquiry';
+type EventType = 'login' | 'registration' | 'newsletter' | 'pwrecovery' | 'newinquiry' | 'contactform';
 
 interface WebhookPayload {
   event_type: EventType;


### PR DESCRIPTION
- Updated contact form API to use new unified webhook system
- Added 'contactform' event type to webhook utility
- Sends first_name, email, and message to Denis's Make.com workflow
- Removed dependency on MAKE_CONTACT_URL environment variable
- Password recovery webhook already integrated and working