### PR TITLE
fix: revert Google logo to original natural size

### DIFF
--- a/src/components/Hero/HomeHero.tsx
+++ b/src/components/Hero/HomeHero.tsx
@@ -20,10 +20,9 @@ export default function HomeHero() {
         <div className="flex items-center justify-center mx-auto w-fit border border-white/20 max-small:flex-col rounded-[40px] py-2.5 px-4 max-medium:hidden gap-3 mb-10">
           <span className="flex items-center justify-start gap-2">
             <Image
-              width={80}
-              height={24}
-              priority
-              sizes="80px"
+              width={0}
+              height={0}
+              sizes="100vw"
               src={google}
               alt="google"
             />


### PR DESCRIPTION
## Summary
Restores Google logo to original natural size (was accidentally shrunk in LCP optimization PR)

## Change
- `width`: 80 → 0 (natural)
- `height`: 24 → 0 (natural)  
- `sizes`: "80px" → "100vw"

## Files Changed
- `src/components/Hero/HomeHero.tsx`