### PR TITLE
Bug fix: alphabetical sorting for users and locals lists

### DIFF
--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/page.tsx
@@ -3,6 +3,7 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import AdminObjekteLocalsDoc from "../../../../../../../components/Admin/ObjekteLocalsAccordion/Admin/AdminObjekteLocalsDoc";
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
+import { buildLocalName } from "@/utils";
 
 export default async function ObjektDetailsPage({
   params,
@@ -12,6 +13,13 @@ export default async function ObjektDetailsPage({
   const { objekt_id, user_id } = await params;
 
   const relatedLocals = await getRelatedLocalsByObjektId(objekt_id);
+
+  // Sort alphabetically by local name
+  relatedLocals.sort((a, b) => {
+    const nameA = buildLocalName(a).toLowerCase();
+    const nameB = buildLocalName(b).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none max-medium:overflow-y-auto grid grid-rows-[auto_1fr]">

--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/zwischenstand/localauswahl/[objekt_id]/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/zwischenstand/localauswahl/[objekt_id]/page.tsx
@@ -5,6 +5,7 @@ import AdminObjekteItemLocalDocAccordion from "../../../../../../../../component
 import ObjekteItemLocalDocAccordion from "../../../../../../../../components/Admin/ObjekteLocalsAccordion/ObjekteItemLocalDocAccordion";
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
 import { cost_type_plus } from "@/static/icons";
+import { buildLocalName } from "@/utils";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -16,6 +17,13 @@ export default async function ObjektDetailsPage({
   const { objekt_id, user_id } = await params;
 
   const relatedLocals = await getRelatedLocalsByObjektId(objekt_id);
+
+  // Sort alphabetically by local name
+  relatedLocals.sort((a, b) => {
+    const nameA = buildLocalName(a).toLowerCase();
+    const nameB = buildLocalName(b).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-[calc(100dvh-53px)] max-medium:max-h-[calc(100dvh-53px)] grid grid-rows-[auto_1fr]">

--- a/src/app/(admin)/admin/[user_id]/objekte/[objekte_id]/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/objekte/[objekte_id]/page.tsx
@@ -5,6 +5,7 @@ import ObjekteLocalsAdminAccordion from "../../../../../../components/Admin/Obje
 import { buildSubRoute } from "@/lib/navigation";
 import { ROUTE_ADMIN, ROUTE_OBJEKTE } from "@/routes/routes";
 import { create_local } from "@/static/icons";
+import { buildLocalName } from "@/utils";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -16,6 +17,13 @@ export default async function AdminObjektDetailsPage({
   const { objekte_id, user_id } = await params;
 
   const relatedLocals = await getRelatedLocalsByObjektId(objekte_id);
+
+  // Sort alphabetically by local name
+  relatedLocals.sort((a, b) => {
+    const nameA = buildLocalName(a).toLowerCase();
+    const nameB = buildLocalName(b).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   const createUnitLink = await buildSubRoute("create-unit");
 

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -9,6 +9,13 @@ import Link from "next/link";
 export default async function AdminPage() {
   const users = await getUsers();
 
+  // Sort alphabetically by email
+  users.sort((a, b) => {
+    const emailA = a.email?.toLowerCase() || '';
+    const emailB = b.email?.toLowerCase() || '';
+    return emailA.localeCompare(emailB);
+  });
+
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none grid grid-rows-[auto_1fr]">
       <Breadcrumb

--- a/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/page.tsx
@@ -3,6 +3,7 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import ObjekteLocalsDoc from "../../../../../components/Admin/ObjekteLocalsAccordion/ObjekteLocalsDoc";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
+import { buildLocalName } from "@/utils";
 
 export default async function ObjektDetailsPage({
   params,
@@ -12,6 +13,13 @@ export default async function ObjektDetailsPage({
   const { objekt_id } = await params;
 
   const relatedLocals = await getRelatedLocalsByObjektId(objekt_id);
+
+  // Sort alphabetically by local name
+  relatedLocals.sort((a, b) => {
+    const nameA = buildLocalName(a).toLowerCase();
+    const nameB = buildLocalName(b).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none grid grid-rows-[auto_1fr]">

--- a/src/app/(admin)/heizkostenabrechnung/zwischenstand/localauswahl/[objekt_id]/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/zwischenstand/localauswahl/[objekt_id]/page.tsx
@@ -4,6 +4,7 @@ import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import ObjekteItemLocalDocAccordion from "../../../../../../components/Admin/ObjekteLocalsAccordion/ObjekteItemLocalDocAccordion";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
 import { cost_type_plus } from "@/static/icons";
+import { buildLocalName } from "@/utils";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -15,6 +16,13 @@ export default async function ObjektDetailsPage({
   const { objekt_id } = await params;
 
   const relatedLocals = await getRelatedLocalsByObjektId(objekt_id);
+
+  // Sort alphabetically by local name
+  relatedLocals.sort((a, b) => {
+    const nameA = buildLocalName(a).toLowerCase();
+    const nameB = buildLocalName(b).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-[calc(100dvh-53px)] max-medium:max-h-[calc(100dvh-53px)] grid grid-rows-[auto_1fr]">

--- a/src/app/(admin)/objekte/[id]/page.tsx
+++ b/src/app/(admin)/objekte/[id]/page.tsx
@@ -4,6 +4,7 @@ import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import ObjekteLocalsAccordion from "../../../../components/Admin/ObjekteLocalsAccordion/ObjekteLocalsAccordion";
 import { ROUTE_OBJEKTE } from "@/routes/routes";
 import { create_local } from "@/static/icons";
+import { buildLocalName } from "@/utils";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -15,6 +16,13 @@ export default async function ObjektDetailsPage({
   const { id } = await params;
 
   const relatedLocals = await getRelatedLocalsByObjektId(id);
+
+  // Sort alphabetically by local name
+  relatedLocals.sort((a, b) => {
+    const nameA = buildLocalName(a).toLowerCase();
+    const nameB = buildLocalName(b).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-[calc(100dvh-53px)] max-medium:max-h-[calc(100dvh-53px)] grid grid-rows-[auto_1fr]">

--- a/src/components/Basic/Dropdown/AdminUsersDropdownContent.tsx
+++ b/src/components/Basic/Dropdown/AdminUsersDropdownContent.tsx
@@ -15,11 +15,17 @@ export default function AdminUsersDropdownContent({
 }: AdminApartmentsDropdownContentProps) {
   const [searchTerm, setSearchTerm] = useState("");
 
-  const filteredUsers = users?.filter(
-    (user) =>
-      user.first_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      user.last_name.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const filteredUsers = users
+    ?.filter(
+      (user) =>
+        user.first_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        user.last_name.toLowerCase().includes(searchTerm.toLowerCase())
+    )
+    .sort((a, b) => {
+      const nameA = `${a.first_name} ${a.last_name}`.toLowerCase();
+      const nameB = `${b.first_name} ${b.last_name}`.toLowerCase();
+      return nameA.localeCompare(nameB);
+    });
 
   return (
     <div className="w-full min-w-[250px] bg-white rounded-base shadow-lg border border-gray-200 px-2.5 py-4 space-y-3 max-medium:max-h-[50vh] max-medium:overflow-hidden max-medium:flex max-medium:flex-col">


### PR DESCRIPTION
Alphabetical sorting names

- Sort admin user list alphabetically by email
- Sort admin user dropdown alphabetically by full name
- Sort locals (Wohneinheiten) alphabetically by name in:
- User objekt details page
- Admin objekt details page
- Heizkostenabrechnung local selection pages (user + admin)
- Heizkostenabrechnung interim report local selection pages (user + admin)