### PR TITLE
Fix: Prevent duplicate questionnaire submissions on rapid clicks

### DIFF
--- a/src/app/(service)/fragebogen/page.tsx
+++ b/src/app/(service)/fragebogen/page.tsx
@@ -315,8 +315,9 @@ export default function FragebogenPage() {
                       className="rounded-xl cursor-pointer bg-green flex items-center justify-center duration-300 hover:opacity-80 text-white font-bold text-[15px] disabled:opacity-50 py-4 px-8 border border-transparent"
                       onClick={isSubmitStep ? undefined : handleClick}
                       type={isSubmitStep ? "submit" : "button"}
+                      disabled={isSubmitStep && mutation.isPending}
                     >
-                      Bestätigen
+                      {isSubmitStep && mutation.isPending ? "Wird gesendet..." : "Bestätigen"}
                     </button>
                   );
                 })()}


### PR DESCRIPTION
## Summary
- Added `disabled` state to submit button using `mutation.isPending`
- Added loading indicator text ("Wird gesendet...") during submission
- Prevents multiple Slack notifications and messages when users click repeatedly

## Root Cause
The submit button had no protection against rapid clicks. Each click triggered a new API call to Make.com webhook, resulting in duplicate Slack notifications.