### PR TITLE
Remove Silverton Logo & Add Kunden Navigation

### DIFF
--- a/src/app/(base)/page.tsx
+++ b/src/app/(base)/page.tsx
@@ -396,117 +396,117 @@ export default async function Home() {
       </div>
       <div className="hero-3 px-[140px] max-megalarge:px-16 max-large:px-6 max-medium:px-5 max-small:px-6">
             <div className="flex max-medium:flex-col max-medium:items-center gap-8 max-medium:gap-6">
-              <p className="text-lg max-small:text-xl text-dark_text max-medium:text-center font-bold max-medium:whitespace-normal whitespace-nowrap max-small:mb-4">
+              <p id="kunden" className="text-lg max-small:text-xl text-dark_text max-medium:text-center font-bold max-medium:whitespace-normal whitespace-nowrap max-small:mb-4" style={{ scrollMarginTop: '85px' }}>
                 Die Wahl führender Innovatoren und Branchenführer
               </p>
               {/* Desktop: 4 columns, evenly spaced */}
               {/* Mobile: 2 columns with space between */}
               <div className="grid flex-1 items-center justify-items-center grid-cols-4 max-medium:grid-cols-3 max-small:grid-cols-2 gap-x-12 gap-y-8 max-small:gap-x-10 max-small:gap-y-6">
                 <Image
-                  width={140}
+                  width={120}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[120px] h-[45px] max-small:w-[85px] max-small:h-[32px] object-contain"
                   src={berlin_bear_green}
                   alt="berlinBear"
                 />
                 <Image
-                  width={140}
+                  width={130}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[130px] h-[45px] max-small:w-[90px] max-small:h-[32px] object-contain"
                   src={dumax_green}
                   alt="dumax"
                 />
                 <Image
-                  width={140}
+                  width={130}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[130px] h-[45px] max-small:w-[90px] max-small:h-[32px] object-contain"
                   src={harte_green}
                   alt="harte"
                 />
                 <Image
-                  width={140}
+                  width={120}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[120px] h-[45px] max-small:w-[85px] max-small:h-[32px] object-contain"
                   src={hsp_green}
                   alt="hsp"
                 />
                 <Image
-                  width={140}
+                  width={125}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[125px] h-[45px] max-small:w-[88px] max-small:h-[32px] object-contain"
                   src={raum_green}
                   alt="raum"
                 />
                 <Image
-                  width={140}
+                  width={135}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[120px] max-small:h-[40px] object-contain"
+                  className="w-[135px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
                   src={schleicher_green}
                   alt="schleicher_green"
                 />
                 <Image
-                  width={140}
+                  width={100}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[70px] max-small:h-[24px] object-contain"
+                  className="w-[100px] h-[45px] max-small:w-[70px] max-small:h-[32px] object-contain"
                   src={vitec_green}
                   alt="vitec"
                 />
                 <Image
-                  width={140}
+                  width={125}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[125px] h-[45px] max-small:w-[88px] max-small:h-[32px] object-contain"
                   src={wagner_green}
                   alt="wagner"
                 />
                 <Image
-                  width={140}
+                  width={130}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[130px] h-[45px] max-small:w-[90px] max-small:h-[32px] object-contain"
                   src={werne_green}
                   alt="werne_green"
                 />
                 <Image
-                  width={140}
+                  width={125}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[125px] h-[45px] max-small:w-[88px] max-small:h-[32px] object-contain"
                   src={neckar_green}
                   alt="neckar_green"
                 />
                 <Image
-                  width={140}
+                  width={120}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[120px] h-[45px] max-small:w-[85px] max-small:h-[32px] object-contain"
                   src={niesen_green}
                   alt="niesen_green"
                 />
                 <Image
-                  width={140}
+                  width={130}
                   height={45}
                   sizes="100vw"
                   loading="lazy"
-                  className="w-[140px] h-[45px] max-small:w-[95px] max-small:h-[32px] object-contain"
+                  className="w-[130px] h-[45px] max-small:w-[90px] max-small:h-[32px] object-contain"
                   src={progera_green}
                   alt="progera_green"
                 />

--- a/src/components/Basic/Ticker/GeraeteHeroTicker.tsx
+++ b/src/components/Basic/Ticker/GeraeteHeroTicker.tsx
@@ -9,7 +9,7 @@ import {
   idgim,
   quarterback,
   raum,
-  silverton,
+
   vitec,
   wagner,
   winfried,
@@ -161,16 +161,7 @@ export default function GeraeteHeroTicker() {
               alt="raum"
             />
           </div>
-          <div className="ticker__item">
-            <Image
-              width={0}
-              height={0}
-              sizes="100vw"
-              loading="lazy"
-              src={silverton}
-              alt="silverton"
-            />
-          </div>
+
           <div className="ticker__item">
             <Image
               width={0}
@@ -271,16 +262,7 @@ export default function GeraeteHeroTicker() {
               alt="raum"
             />
           </div>
-          <div className="ticker__item">
-            <Image
-              width={0}
-              height={0}
-              sizes="100vw"
-              loading="lazy"
-              src={silverton}
-              alt="silverton"
-            />
-          </div>
+
           <div className="ticker__item">
             <Image
               width={0}
@@ -381,16 +363,7 @@ export default function GeraeteHeroTicker() {
               alt="raum"
             />
           </div>
-          <div className="ticker__item">
-            <Image
-              width={0}
-              height={0}
-              sizes="100vw"
-              loading="lazy"
-              src={silverton}
-              alt="silverton"
-            />
-          </div>
+
           <div className="ticker__item">
             <Image
               width={0}

--- a/src/components/Basic/Ticker/HeroTicker.tsx
+++ b/src/components/Basic/Ticker/HeroTicker.tsx
@@ -5,7 +5,7 @@ import {
   hsp,
   idgim,
   quarterback,
-  silverton,
+
   vitec,
   wagner,
   winfried,
@@ -76,16 +76,7 @@ export default function HeroTicker() {
             alt="quarterback"
           />
         </div>
-        <div className="ticker__item">
-          <Image
-            width={0}
-            height={0}
-            sizes="100vw"
-            loading="lazy"
-            src={silverton}
-            alt="silverton"
-          />
-        </div>
+
         <div className="ticker__item">
           <Image
             width={0}
@@ -176,16 +167,7 @@ export default function HeroTicker() {
             alt="quarterback"
           />
         </div>
-        <div className="ticker__item">
-          <Image
-            width={0}
-            height={0}
-            sizes="100vw"
-            loading="lazy"
-            src={silverton}
-            alt="silverton"
-          />
-        </div>
+
         <div className="ticker__item">
           <Image
             width={0}
@@ -276,16 +258,7 @@ export default function HeroTicker() {
             alt="quarterback"
           />
         </div>
-        <div className="ticker__item">
-          <Image
-            width={0}
-            height={0}
-            sizes="100vw"
-            loading="lazy"
-            src={silverton}
-            alt="silverton"
-          />
-        </div>
+
         <div className="ticker__item">
           <Image
             width={0}

--- a/src/components/Header/Nav.tsx
+++ b/src/components/Header/Nav.tsx
@@ -238,7 +238,7 @@ export default function Nav() {
       <div className="max-large:py-3 max-large:w-full max-large:text-center">
         <Link
           onClick={() => handleBurgerMenu()}
-          href={ROUTE_HOME}
+          href="/#kunden"
           className="flex items-center text-base max-xl:text-sm text-dark_text justify-center gap-2 max-large:text-base"
         >
           Kunden

--- a/src/static/icons.ts
+++ b/src/static/icons.ts
@@ -290,7 +290,7 @@ import hsp from "@/asset/hsp.png";
 import idgim from "@/asset/idgim.png";
 import quarterback from "@/asset/quarterback.png";
 import raum from "@/asset/raum.png";
-import silverton from "@/asset/silverton.png";
+
 import vitec from "@/asset/vitec.png";
 import wagner from "@/asset/wagner.png";
 import winfried from "@/asset/winfried.png";
@@ -340,7 +340,7 @@ export {
   idgim,
   quarterback,
   raum,
-  silverton,
+
   vitec,
   wagner,
   winfried,


### PR DESCRIPTION
## Changes

### Removed Silverton Logo
- Removed from HeroTicker component
- Removed from GeraeteHeroTicker component
- Cleaned up icons.ts exports

### Added Kunden Navigation
- New "Kunden" link in main nav scrolls to customer section
- Smooth scroll with 85px offset for fixed header
- Mobile menu auto-closes on click

### Improved Logo Layout
- Adjusted logo sizes for better visual balance (100px-135px range)
- Maintains aspect ratios with `object-contain`
- Responsive sizing for mobile

## Technical Notes
- Uses CSS `scroll-margin-top` for scroll offset
- All logos preserve brand integrity