### PR TITLE
fix: make Vorname, Nachname, Email mandatory in questionnaire

### DIFF
--- a/src/app/(service)/fragebogen/page.tsx
+++ b/src/app/(service)/fragebogen/page.tsx
@@ -49,9 +49,9 @@ const formSchema = z.object({
   ort: z.string().optional().or(z.literal("")),
   
   // Contact form fields (Q6 - Personal)
-  email: z.string().email("Ungültige E-Mail-Adresse").or(z.literal("")),
-  first_name: z.string().min(1, "Vorname ist erforderlich").or(z.literal("")),
-  last_name: z.string().min(1, "Nachname ist erforderlich").or(z.literal("")),
+  email: z.string().email("Bitte geben Sie eine gültige E-Mail-Adresse ein"),
+  first_name: z.string().min(1, "Bitte füllen Sie dieses Feld aus"),
+  last_name: z.string().min(1, "Bitte füllen Sie dieses Feld aus"),
   form_confirm: z.boolean().refine((val) => val === true, {
     message: "Bitte akzeptieren Sie die Datenschutzbestimmungen",
   }),

--- a/src/components/Fragebogen/Steps/Over50/StepSixOver50.tsx
+++ b/src/components/Fragebogen/Steps/Over50/StepSixOver50.tsx
@@ -28,9 +28,9 @@ export default function StepSixOver50({
 							{...register("first_name")}
 							id="first_name"
 						/>
-						{errors.first_name && (
-							<p className="text-red-500 text-sm mt-1">{errors.first_name.message}</p>
-						)}
+					{errors.first_name && (
+						<p className="text-dark_text/50 text-sm mt-1">{errors.first_name.message}</p>
+					)}
 					</label>
 					<label htmlFor="last_name" className="block flex-1">
 						<input
@@ -40,9 +40,9 @@ export default function StepSixOver50({
 							{...register("last_name")}
 							id="last_name"
 						/>
-						{errors.last_name && (
-							<p className="text-red-500 text-sm mt-1">{errors.last_name.message}</p>
-						)}
+					{errors.last_name && (
+						<p className="text-dark_text/50 text-sm mt-1">{errors.last_name.message}</p>
+					)}
 					</label>
 				</div>
 				<label className="block max-w-[509px]" htmlFor="email">
@@ -53,9 +53,9 @@ export default function StepSixOver50({
 						type="email"
 						id="email"
 					/>
-					{errors.email && (
-						<p className="text-red-500 text-sm mt-1">{errors.email.message}</p>
-					)}
+			{errors.email && (
+				<p className="text-dark_text/50 text-sm mt-1">{errors.email.message}</p>
+			)}
 				</label>
 				<label
 					htmlFor="form_confirm"
@@ -80,9 +80,9 @@ export default function StepSixOver50({
 						gelesen und akzeptiert
 					</span>
 				</label>
-				{errors.form_confirm && (
-					<p className="text-red-500 text-sm">{errors.form_confirm.message}</p>
-				)}
+		{errors.form_confirm && (
+			<p className="text-red-500 text-sm">{errors.form_confirm.message}</p>
+		)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
- Remove .or(z.literal('')) from first_name, last_name, email in Zod schema
- Error messages use soft styling (text-dark_text/50) instead of red
- Works for both Over50 and Under50 flows