### PR TITLE
feat: add EIE manufacturer support for Maienweg smoke detectors

### DIFF
--- a/src/utils/errorFlagInterpreter.ts
+++ b/src/utils/errorFlagInterpreter.ts
@@ -77,8 +77,19 @@ const MANUFACTURER_ERROR_MAPPINGS: Record<string, Record<number, string>> = {
     2: "Batterie schwach",                      // Power Low (Bit 2)
     3: "Gerätefehler dauerhaft",                // Permanent Error (Bit 3)
     4: "Gerätefehler temporär"                  // Temporary Error (Bit 4)
-  }
+  },
 
+  // Ei Electronics Smoke Detectors (EIE)
+  EIE: {
+    0: "Rauchalarm",                            // Smoke alarm detected!
+    1: "Verschmutzung",                         // Sensor dirty/contamination
+    2: "Batterie schwach",                      // Low battery
+    3: "Entnahme erkannt",                      // Device removal detected (tamper)
+    4: "Hindernis erkannt",                     // Obstacle detected
+    5: "Testalarm",                             // Test alarm
+    6: "Gerätestörung",                         // Device fault
+    7: "Funksignal schwach"                     // Weak radio signal
+  }
 
 };
 

--- a/supabase/functions/csv-parser/errorNotifications.ts
+++ b/supabase/functions/csv-parser/errorNotifications.ts
@@ -61,6 +61,17 @@ const MANUFACTURER_ERROR_MAPPINGS: Record<string, Record<number, string>> = {
         2: "Batterie schwach",
         3: "Gerätefehler dauerhaft",
         4: "Gerätefehler temporär"
+    },
+    // Ei Electronics Smoke Detectors (EIE)
+    EIE: {
+        0: "Rauchalarm",
+        1: "Verschmutzung",
+        2: "Batterie schwach",
+        3: "Entnahme erkannt",
+        4: "Hindernis erkannt",
+        5: "Testalarm",
+        6: "Gerätestörung",
+        7: "Funksignal schwach"
     }
 };
 


### PR DESCRIPTION
## Summary
Adds EIE (Ei Electronics) manufacturer support for smoke detector error interpretation.

## Changes
- Added EIE to `MANUFACTURER_ERROR_MAPPINGS` in `src/utils/errorFlagInterpreter.ts`
- Added EIE to error mappings in `supabase/functions/csv-parser/errorNotifications.ts`

## Why
Maienweg96Hamburg customer uses Ei Electronics (EIE) smoke detectors. Without this mapping, error flags would display as "Unknown error bit X" instead of proper German text like "Rauchalarm" or "Batterie schwach".

## Testing
- ✅ Uploaded Maienweg CSV - 65 rows parsed successfully
- ✅ EIE manufacturer mapping verified in both files

📝 Note: After merging, the Supabase Edge Function needs manual deployment:
supabase functions deploy csv-parser