### PR TITLE
Fix: Add 5-layer spam protection to contact form

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,12 +1,96 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { sendWebhookEvent } from "@/utils/webhooks";
+import { checkIPRateLimit, getClientIP } from "@/app/api/bved/v1/_lib/rate-limit";
 
+// ─── Server-side validation (mirrors frontend schema) ───────────────────────
+const contactSchema = z.object({
+    name: z.string().min(3).max(100),
+    email: z.string().email().max(254),
+    message: z.string().min(10).max(5000),
+    infoChecked: z.literal(true),
+    _hp: z.string().optional(),  // honeypot
+    _t: z.number().optional(),   // form load timestamp
+});
+
+// ─── Gibberish detection ─────────────────────────────────────────────────────
+// Detects random strings like "wyichtvxKjBGMhTz" or "mKfLTlwpwMchpAQpq"
+// by checking consonant-to-total-letter ratio. Real text in any Latin-script
+// language has vowels; random bot strings don't.
+const VOWELS = new Set("aeiouAEIOUäöüÄÖÜàáâãèéêìíîòóôùúûñ");
+
+function isGibberish(text: string): boolean {
+    // Strip non-letter characters
+    const letters = text.replace(/[^a-zA-ZäöüÄÖÜàáâãèéêìíîòóôùúûñ]/g, "");
+    if (letters.length < 5) return false; // too short to judge
+
+    const vowelCount = [...letters].filter((ch) => VOWELS.has(ch)).length;
+    const vowelRatio = vowelCount / letters.length;
+
+    // Real text: ~35-45% vowels. Gibberish like "wyichtvxKjBGMhTz": <15%
+    // Threshold at 15% is very conservative — catches obvious gibberish only
+    if (vowelRatio < 0.15) return true;
+
+    // Also check for no spaces in long text (real messages have word breaks)
+    if (text.length > 20 && !text.includes(" ")) return true;
+
+    return false;
+}
+
+// ─── Silent rejection helper ─────────────────────────────────────────────────
+// Returns 200 OK to avoid tipping off bots about what triggered the block
+function silentReject(reason: string) {
+    console.log(`[CONTACT][SPAM] Blocked: ${reason}`);
+    return NextResponse.json({ success: true });
+}
+
+// ─── POST handler ────────────────────────────────────────────────────────────
 export async function POST(req: Request) {
     try {
-        const { name, email, message } = await req.json();
+        const body = await req.json();
 
-        // ✅ NEW: Use unified webhook with event_type 'contactform'
-        // Send contact form data to Denis's Make.com workflow
+        // Layer 1: Honeypot check
+        // Bots auto-fill the hidden "website" field; real users never see it
+        if (body._hp && body._hp.length > 0) {
+            return silentReject(`honeypot filled: "${body._hp}"`);
+        }
+
+        // Layer 2: Timing check
+        // Bots submit instantly; real humans need at least 3 seconds
+        if (body._t) {
+            const elapsed = Date.now() - body._t;
+            if (elapsed < 3000) {
+                return silentReject(`too fast: ${elapsed}ms`);
+            }
+        }
+
+        // Layer 3: Server-side Zod validation
+        const parsed = contactSchema.safeParse(body);
+        if (!parsed.success) {
+            console.log(`[CONTACT][SPAM] Validation failed:`, parsed.error.flatten());
+            return NextResponse.json(
+                { error: "Ungültige Eingabe. Bitte überprüfen Sie Ihre Angaben." },
+                { status: 400 }
+            );
+        }
+
+        const { name, email, message } = parsed.data;
+
+        // Layer 4: Gibberish detection
+        // Catches random strings like "wyichtvxKjBGMhTz" / "mKfLTlwpwMchpAQpq"
+        if (isGibberish(name) || isGibberish(message)) {
+            return silentReject(`gibberish detected — name: "${name}", message: "${message}"`);
+        }
+
+        // Layer 5: IP-based rate limiting (max 3 submissions per 10 minutes)
+        // Reuses the existing BVED rate-limit utility
+        const ip = getClientIP(req);
+        const rateLimit = checkIPRateLimit(ip, 3, 600); // 3 per 600s (10 min)
+        if (!rateLimit.allowed) {
+            return silentReject(`rate limit exceeded for IP: ${ip}`);
+        }
+
+        // ✅ All checks passed — send to Make.com → Slack
         await sendWebhookEvent('contactform', email, {
             first_name: name,
             message: message,


### PR DESCRIPTION
## Summary

Addresses daily spam submissions reaching Slack via the contact form. Spam pattern: random gibberish strings like `wyichtvxKjBGMhTz` for name and `mKfLTlwpwMchpAQpq` for message.

### 5 Defense Layers Added

| Layer | What it does | How spam gets caught |
|---|---|---|
| **1. Honeypot** | Hidden `website` field invisible to users | Bots auto-fill it |
| **2. Timing** | Reject if submitted in < 3 seconds | Bots submit instantly |
| **3. Server-side Zod** | Validates name/email/message server-side | Malformed payloads |
| **4. Gibberish detection** | Rejects text with < 15% vowels or no spaces in 20+ chars | `wyichtvxKjBGMhTz` has ~6% vowels |
| **5. IP rate limit** | Max 3 submissions per IP per 10 min | Repeat bot from same IP |

### Files Changed

- `src/components/Kontakt/ContactForm.tsx` - Added honeypot field + timestamp tracking
- `src/app/api/contact/route.ts` - Added all 5 validation layers

### Safety

- All spam rejections return `200 OK` with `{ success: true }` to avoid tipping off bots
- Reuses existing `rate-limit.ts` utility from BVED API (no new dependencies)
- Conservative thresholds to avoid false positives on real users
- Zero breaking changes to legitimate form submissions