### PR TITLE
 Fix: Contact form spam protection and EIE manufacturer support

### DIFF
--- a/src/utils/errorFlagInterpreter.ts
+++ b/src/utils/errorFlagInterpreter.ts
@@ -77,8 +77,19 @@ const MANUFACTURER_ERROR_MAPPINGS: Record<string, Record<number, string>> = {
     2: "Batterie schwach",                      // Power Low (Bit 2)
     3: "Gerätefehler dauerhaft",                // Permanent Error (Bit 3)
     4: "Gerätefehler temporär"                  // Temporary Error (Bit 4)
-  }
+  },
 
+  // Ei Electronics Smoke Detectors (EIE)
+  EIE: {
+    0: "Rauchalarm",                            // Smoke alarm detected!
+    1: "Verschmutzung",                         // Sensor dirty/contamination
+    2: "Batterie schwach",                      // Low battery
+    3: "Entnahme erkannt",                      // Device removal detected (tamper)
+    4: "Hindernis erkannt",                     // Obstacle detected
+    5: "Testalarm",                             // Test alarm
+    6: "Gerätestörung",                         // Device fault
+    7: "Funksignal schwach"                     // Weak radio signal
+  }
 
 };
 

--- a/supabase/functions/csv-parser/errorNotifications.ts
+++ b/supabase/functions/csv-parser/errorNotifications.ts
@@ -61,6 +61,17 @@ const MANUFACTURER_ERROR_MAPPINGS: Record<string, Record<number, string>> = {
         2: "Batterie schwach",
         3: "Gerätefehler dauerhaft",
         4: "Gerätefehler temporär"
+    },
+    // Ei Electronics Smoke Detectors (EIE)
+    EIE: {
+        0: "Rauchalarm",
+        1: "Verschmutzung",
+        2: "Batterie schwach",
+        3: "Entnahme erkannt",
+        4: "Hindernis erkannt",
+        5: "Testalarm",
+        6: "Gerätestörung",
+        7: "Funksignal schwach"
     }
 };
 


### PR DESCRIPTION
## Summary
Bug fixes for contact form spam and smoke detector manufacturer support.

## 🔧 Fixes

### Contact Form Spam Protection (@nicuk)
- fix: add 5-layer spam protection to contact form
  - Honeypot field, timing validation, Zod validation, gibberish detection, IP rate limiting
  - Silent rejection returns 200 OK to avoid tipping off bots

### Manufacturer Support (@Stephnisim)
- feat: add EIE manufacturer support for Maienweg smoke detectors
  - Added EIE to error mappings in frontend and Supabase Edge Function

## 📋 PRs Included
| PR | Title | Author |
|----|-------|--------|
| #220 | 5-layer spam protection | @nicuk |
| #215 | EIE manufacturer support | @Stephnisim |

## 👥 Contributors
| Contributor | Changes |
|-------------|---------|
| @nicuk | Contact form spam protection |
| @Stephnisim | EIE smoke detector support |