### PR TITLE
Fix: Login Webhook Race Condition (Make.com Integration) [@Nic]

### DIFF
--- a/src/components/Basic/Dialog/LoginDialog.tsx
+++ b/src/components/Basic/Dialog/LoginDialog.tsx
@@ -77,17 +77,18 @@ export default function LoginDialog() {
           return;
         }
 
+        // Send login event to Make.com webhook BEFORE navigation
+        // (router.push unmounts the component and cancels pending fetches)
+        sendLoginEvent(session.user.email || email);
+
+        toast.success("Login erfolgreich");
+        closeDialog("login");
+
         if (userData?.permission === "admin") {
           router.push("/admin");
         } else {
           router.push(ROUTE_DASHBOARD);
         }
-
-        // Send login event to Make.com webhook
-        sendLoginEvent(session.user.email || email);
-
-        toast.success("Login erfolgreich");
-        closeDialog("login");
       }
     } catch (e) {
       console.error("Unexpected login error:", e);


### PR DESCRIPTION
## Summary
- Fixed race condition where `router.push()` was called before `sendLoginEvent()`, causing the webhook request to be cancelled when the component unmounted
- Login notifications to Make.com were silently failing because navigation aborted the pending fetch

## Changes
- Reordered operations in `LoginDialog.tsx`: webhook call now fires before navigation
- No functional changes to the login flow itself

## Related
- Resolves Denis's report that login notifications were not arriving in Make.com