### PR TITLE
feat: Implement heating bill PDF generation and download functionality

### DIFF
--- a/src/app/api/download-heating-bill/route.ts
+++ b/src/app/api/download-heating-bill/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseServer } from "@/utils/supabase/server";
+
+/**
+ * POST /api/download-heating-bill
+ * Returns a presigned URL for an already-generated heating bill PDF.
+ * Accepts: { objektId, localId, docId }
+ * Returns: { presignedUrl } or 404 if PDF does not exist.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await supabaseServer();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized - Please login" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { objektId, localId, docId } = body as {
+      objektId?: string;
+      localId?: string;
+      docId?: string;
+    };
+
+    if (!docId || !objektId || !localId) {
+      return NextResponse.json(
+        { error: "Missing required fields: objektId, localId, docId" },
+        { status: 400 }
+      );
+    }
+
+    const storagePath = `${user.id}/${objektId}/${localId}/heating-bill_${docId}.pdf`;
+
+    const { data: signedData, error: signedError } =
+      await supabase.storage
+        .from("documents")
+        .createSignedUrl(storagePath, 3600, { download: true });
+
+    if (signedError || !signedData?.signedUrl) {
+      return NextResponse.json(
+        { error: "PDF not found or not ready yet" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      presignedUrl: signedData.signedUrl,
+    });
+  } catch (error: unknown) {
+    console.error("Download heating bill error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to get download URL",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/generate-heating-bills-batch/route.ts
+++ b/src/app/api/generate-heating-bills-batch/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "node:path";
+import { supabaseServer } from "@/utils/supabase/server";
+import { renderToBuffer } from "@react-pdf/renderer";
+import React from "react";
+import HeidiSystemsPdf from "@/components/Admin/Docs/Render/HeidiSystemsPdf/HeidiSystemsPdf";
+import {
+  mockHeatingBillModel,
+  fetchHeatingBillData,
+  computeHeatingBill,
+  validateModel,
+} from "@/app/api/generate-heating-bill/_lib";
+import { getRelatedLocalsByObjektId } from "@/api";
+
+/** When "true" or "1", always use mock model (for testing/rollback). */
+const HEATING_BILL_USE_MOCK =
+  process.env.HEATING_BILL_USE_MOCK === "true" ||
+  process.env.HEATING_BILL_USE_MOCK === "1";
+
+/**
+ * POST /api/generate-heating-bills-batch
+ * Generates heating bill PDFs for all locals in a building.
+ * Accepts: { objektId, docId }
+ * Returns: { success: true, generated: number, failed: number }
+ *
+ * Fire-and-forget: caller redirects immediately; generation runs in background.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await supabaseServer();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized - Please login" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { objektId, docId } = body as { objektId?: string; docId?: string };
+
+    if (!docId || !objektId) {
+      return NextResponse.json(
+        { error: "Missing required fields: objektId, docId" },
+        { status: 400 }
+      );
+    }
+
+    const locals = await getRelatedLocalsByObjektId(objektId);
+    if (!locals || locals.length === 0) {
+      return NextResponse.json(
+        { success: true, generated: 0, failed: 0, message: "No locals found" },
+        { status: 200 }
+      );
+    }
+
+    // Fetch and compute once (building-level data shared across all locals)
+    let model = mockHeatingBillModel;
+    if (!HEATING_BILL_USE_MOCK) {
+      try {
+        const raw = await fetchHeatingBillData(docId, user.id, {
+          useServiceRole: true,
+        });
+        model = computeHeatingBill(raw);
+        const validation = validateModel(model);
+        if (!validation.valid && validation.errors.length > 0) {
+          console.warn(
+            "[HeatingBillBatch] Validation errors:",
+            validation.errors
+          );
+        }
+      } catch (fetchError) {
+        if (process.env.NODE_ENV === "development") {
+          console.warn(
+            "[HeatingBillBatch] Compute failed, using mock:",
+            fetchError
+          );
+        }
+      }
+    }
+
+    // Resolve logo for server-side rendering
+    model = {
+      ...model,
+      logoSrc: path.join(process.cwd(), "public", "admin_logo.png"),
+    };
+
+    // Render PDF once (same content for all locals)
+    const buffer = await renderToBuffer(
+      React.createElement(HeidiSystemsPdf, { model }) as any
+    );
+
+    let generated = 0;
+    let failed = 0;
+
+    for (const local of locals) {
+      const localId = local.id;
+      if (!localId) {
+        failed++;
+        continue;
+      }
+
+      const storagePath = `${user.id}/${objektId}/${localId}/heating-bill_${docId}.pdf`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("documents")
+        .upload(storagePath, buffer, {
+          contentType: "application/pdf",
+          upsert: true,
+        });
+
+      if (uploadError) {
+        console.error(
+          `[HeatingBillBatch] Upload failed for local ${localId}:`,
+          uploadError
+        );
+        failed++;
+      } else {
+        generated++;
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      generated,
+      failed,
+    });
+  } catch (error: unknown) {
+    console.error("Generate heating bills batch error:", error);
+    return NextResponse.json(
+      {
+        error: "Batch PDF generation failed",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/Admin/Forms/DocPreparing/Common/SaveCostButton.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Common/SaveCostButton.tsx
@@ -74,6 +74,16 @@ export default function SaveCostButton({
           redirectUrl = `${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/${objektId}/${localId}/${operatingDocId}/results`;
         } else {
           redirectUrl = `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+          // Fire-and-forget: trigger batch PDF generation for all locals
+          fetch("/api/generate-heating-bills-batch", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              objektId,
+              docId: operatingDocId,
+            }),
+            keepalive: true,
+          }).catch(() => {});
         }
       }
       router.push(redirectUrl);

--- a/src/components/Admin/ObjekteLocalItem/Admin/AdminObjekteLocalItemHeatingBillDocResult.tsx
+++ b/src/components/Admin/ObjekteLocalItem/Admin/AdminObjekteLocalItemHeatingBillDocResult.tsx
@@ -2,16 +2,7 @@ import { blue_x, gmail, green_check_circle, pdf_icon } from "@/static/icons";
 import { UnitType, type LocalType } from "@/types";
 import { buildLocalName, handleLocalTypeIcon } from "@/utils";
 import Image from "next/image";
-import {
-  getAdminContractsWithContractorsByLocalID,
-  getAdminHeatingBillDocumentByID,
-  getAdminHeatingInvoicesByHeatingBillDocumentID,
-  getAdminUserData,
-  getDocCostCategoryTypes,
-  getLocalById,
-  getObjectById,
-  getRelatedLocalsByObjektId,
-} from "@/api";
+import { getAdminContractsWithContractorsByLocalID } from "@/api";
 import ThreeDotsButton from "@/components/Basic/TheeDotsButton/TheeDotsButton";
 import Link from "next/link";
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
@@ -73,25 +64,6 @@ export default async function AdminObjekteLocalItemHeatingBillDocResult({
         );
     }
   };
-
-  const objekt = await getObjectById(objektID);
-  const relatedLocals = await getRelatedLocalsByObjektId(objektID);
-  const costCategories = await getDocCostCategoryTypes("heizkostenabrechnung");
-  const mainDoc = await getAdminHeatingBillDocumentByID(
-    docID ? docID : "",
-    userID
-  );
-  const invoices = await getAdminHeatingInvoicesByHeatingBillDocumentID(
-    docID ? docID : "",
-    userID
-  );
-  const local = await getLocalById(item.id ?? "");
-  const user = await getAdminUserData(userID);
-
-  const totalLivingSpace =
-    relatedLocals?.reduce((sum, local) => {
-      return sum + (Number(local.living_space) || 0);
-    }, 0) || 0;
 
   const previewLink =
     docType === "objektauswahl"
@@ -157,14 +129,9 @@ export default async function AdminObjekteLocalItemHeatingBillDocResult({
             />
           </Link>
           <LocalPDFDownloadButton
-            mainDoc={mainDoc}
-            local={local}
-            totalLivingSpace={totalLivingSpace}
-            costCategories={costCategories}
-            invoices={invoices}
-            contracts={contracts}
-            user={user}
-            objekt={objekt}
+            objektId={objektID}
+            localId={item.id ?? ""}
+            docId={docID ?? ""}
           />
           <button>
             <Image

--- a/src/components/Admin/ObjekteLocalItem/HeatingBillActionButtons.tsx
+++ b/src/components/Admin/ObjekteLocalItem/HeatingBillActionButtons.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { gmail, pdf_icon } from "@/static/icons";
+import LocalPDFDownloadButton from "../Docs/Render/HeidiSystemsPdf/LocalPDFDownloadButton";
+import ThreeDotsButton from "@/components/Basic/TheeDotsButton/TheeDotsButton";
+
+const POLL_INTERVAL_MS = 5000;
+
+export type HeatingBillActionButtonsProps = {
+  objektId: string;
+  localId: string;
+  docId: string;
+  previewHref: string;
+  editLink: string;
+  docType: "localauswahl" | "objektauswahl";
+};
+
+export default function HeatingBillActionButtons({
+  objektId,
+  localId,
+  docId,
+  previewHref,
+  editLink,
+  docType,
+}: Readonly<HeatingBillActionButtonsProps>) {
+  const [pdfReady, setPdfReady] = useState<boolean | null>(null);
+
+  const checkPdfReady = useCallback(async () => {
+    if (!docId || !objektId || !localId) return;
+    try {
+      const res = await fetch("/api/download-heating-bill", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ objektId, localId, docId }),
+      });
+      setPdfReady(res.ok);
+    } catch {
+      setPdfReady(false);
+    }
+  }, [objektId, localId, docId]);
+
+  useEffect(() => {
+    checkPdfReady();
+  }, [checkPdfReady]);
+
+  useEffect(() => {
+    if (pdfReady === true || pdfReady === null) return;
+    const interval = setInterval(checkPdfReady, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [pdfReady, checkPdfReady]);
+
+  const isDisabled = pdfReady !== true;
+  const disabledTooltip = "Wird generiert...";
+
+  return (
+    <div className="flex items-center justify-end max-medium:justify-center gap-12 max-medium:gap-4">
+      <div className="flex items-center justify-end max-medium:justify-center gap-4 max-medium:gap-3">
+        <span
+          className={
+            isDisabled
+              ? "inline-flex opacity-50 cursor-not-allowed"
+              : "inline-flex"
+          }
+          title={isDisabled ? disabledTooltip : undefined}
+        >
+          {isDisabled ? (
+            <span className="pointer-events-none">
+              <Image
+                width={0}
+                height={0}
+                sizes="100vw"
+                loading="lazy"
+                className="max-w-10 max-h-10 max-xl:max-w-6 max-xl:max-h-6 max-medium:max-w-8 max-medium:max-h-8"
+                src={pdf_icon}
+                alt="pdf_icon"
+              />
+            </span>
+          ) : (
+            <Link href={previewHref}>
+              <Image
+                width={0}
+                height={0}
+                sizes="100vw"
+                loading="lazy"
+                className="max-w-10 max-h-10 max-xl:max-w-6 max-xl:max-h-6 max-medium:max-w-8 max-medium:max-h-8"
+                src={pdf_icon}
+                alt="pdf_icon"
+              />
+            </Link>
+          )}
+        </span>
+
+        <span
+          className={
+            isDisabled
+              ? "inline-flex opacity-50 cursor-not-allowed pointer-events-none"
+              : "inline-flex"
+          }
+          title={isDisabled ? disabledTooltip : undefined}
+        >
+          <LocalPDFDownloadButton
+            objektId={objektId}
+            localId={localId}
+            docId={docId}
+          />
+        </span>
+
+        <span
+          className={
+            isDisabled
+              ? "inline-flex opacity-50 cursor-not-allowed pointer-events-none"
+              : "inline-flex"
+          }
+          title={isDisabled ? disabledTooltip : undefined}
+        >
+          <button type="button" disabled={isDisabled} aria-disabled={isDisabled}>
+            <Image
+              width={0}
+              height={0}
+              sizes="100vw"
+              loading="lazy"
+              className="max-w-[35px] max-h-[35px] max-xl:max-w-6 max-xl:max-h-6 max-medium:max-w-8 max-medium:max-h-8"
+              src={gmail}
+              alt="gmail_icon"
+            />
+          </button>
+        </span>
+
+        <div className="max-medium:hidden">
+          <ThreeDotsButton
+            dialogAction="heating_bill_delete"
+            editLink={editLink}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Admin/ObjekteLocalItem/ObjekteLocalItemHeatingBillDocResult.tsx
+++ b/src/components/Admin/ObjekteLocalItem/ObjekteLocalItemHeatingBillDocResult.tsx
@@ -2,16 +2,7 @@ import { blue_x, gmail, green_check_circle, pdf_icon } from "@/static/icons";
 import { UnitType, type LocalType } from "@/types";
 import { buildLocalName, handleLocalTypeIcon } from "@/utils";
 import Image from "next/image";
-import {
-  getContractsWithContractorsByLocalID,
-  getDocCostCategoryTypes,
-  getHeatingBillDocumentByID,
-  getHeatingInvoicesByHeatingBillDocumentID,
-  getLocalById,
-  getObjectById,
-  getRelatedLocalsByObjektId,
-  getUserData,
-} from "@/api";
+import { getContractsWithContractorsByLocalID } from "@/api";
 import ThreeDotsButton from "@/components/Basic/TheeDotsButton/TheeDotsButton";
 import Link from "next/link";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
@@ -68,21 +59,6 @@ export default async function ObjekteLocalItemHeatingBillDocResult({
         );
     }
   };
-
-  const objekt = await getObjectById(id);
-  const relatedLocals = await getRelatedLocalsByObjektId(id);
-  const costCategories = await getDocCostCategoryTypes("heizkostenabrechnung");
-  const mainDoc = await getHeatingBillDocumentByID(docID ? docID : "");
-  const invoices = await getHeatingInvoicesByHeatingBillDocumentID(
-    docID ? docID : ""
-  );
-  const local = await getLocalById(item.id ?? "");
-  const user = await getUserData();
-
-  const totalLivingSpace =
-    relatedLocals?.reduce((sum, local) => {
-      return sum + (Number(local.living_space) || 0);
-    }, 0) || 0;
 
   return (
     <div
@@ -149,14 +125,9 @@ export default async function ObjekteLocalItemHeatingBillDocResult({
             />
           </button>
           <LocalPDFDownloadButton
-            mainDoc={mainDoc}
-            local={local}
-            user={user}
-            totalLivingSpace={totalLivingSpace}
-            costCategories={costCategories}
-            invoices={invoices}
-            contracts={contracts}
-            objekt={objekt}
+            objektId={id}
+            localId={item.id ?? ""}
+            docId={docID ?? ""}
           />
           {/* Three dots - visible only on desktop */}
           <div className="max-medium:hidden">

--- a/src/components/Admin/ObjekteLocalItem/ObjekteObjektItemHeatingBillDocResult.tsx
+++ b/src/components/Admin/ObjekteLocalItem/ObjekteObjektItemHeatingBillDocResult.tsx
@@ -1,22 +1,11 @@
-import { blue_x, gmail, green_check_circle, pdf_icon } from "@/static/icons";
+import { blue_x, green_check_circle } from "@/static/icons";
 import { UnitType, type LocalType } from "@/types";
 import { buildLocalName, handleLocalTypeIcon } from "@/utils";
 import Image from "next/image";
-import {
-  getContractsWithContractorsByLocalID,
-  getDocCostCategoryTypes,
-  getHeatingBillDocumentByID,
-  getHeatingInvoicesByHeatingBillDocumentID,
-  getInvoicesByHeatingBillDocumentID,
-  getLocalById,
-  getObjectById,
-  getRelatedLocalsByObjektId,
-  getUserData,
-} from "@/api";
+import { getContractsWithContractorsByLocalID } from "@/api";
 import ThreeDotsButton from "@/components/Basic/TheeDotsButton/TheeDotsButton";
-import Link from "next/link";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import LocalPDFDownloadButton from "../Docs/Render/HeidiSystemsPdf/LocalPDFDownloadButton";
+import HeatingBillActionButtons from "./HeatingBillActionButtons";
 
 export type ObjekteLocalItemHeatingBillDocResultProps = {
   item: LocalType;
@@ -70,21 +59,6 @@ export default async function ObjekteObjektItemHeatingBillDocResult({
     }
   };
 
-  const objekt = await getObjectById(id);
-  const relatedLocals = await getRelatedLocalsByObjektId(id);
-  const costCategories = await getDocCostCategoryTypes("heizkostenabrechnung");
-  const mainDoc = await getHeatingBillDocumentByID(docID ? docID : "");
-  const invoices = await getHeatingInvoicesByHeatingBillDocumentID(
-    docID ? docID : ""
-  );
-  const local = await getLocalById(item.id ?? "");
-  const user = await getUserData();
-
-  const totalLivingSpace =
-    relatedLocals?.reduce((sum, local) => {
-      return sum + (Number(local.living_space) || 0);
-    }, 0) || 0;
-
   return (
     <div
       className={`bg-white p-2 max-medium:p-3 rounded-2xl max-medium:rounded-xl ${
@@ -124,52 +98,14 @@ export default async function ObjekteObjektItemHeatingBillDocResult({
         </div>
       </div>
       {/* Bottom row: Action buttons */}
-      <div className="flex items-center justify-end max-medium:justify-center gap-12 max-medium:gap-4">
-        <div className="flex items-center justify-end max-medium:justify-center gap-4 max-medium:gap-3">
-          <Link
-            href={`${ROUTE_HEIZKOSTENABRECHNUNG}/${docType}/${id}/${docID}/results/${item.id}/preview`}
-          >
-            <Image
-              width={0}
-              height={0}
-              sizes="100vw"
-              loading="lazy"
-              className="max-w-10 max-h-10 max-xl:max-w-6 max-xl:max-h-6 max-medium:max-w-8 max-medium:max-h-8"
-              src={pdf_icon}
-              alt={"pdf_icon"}
-            />
-          </Link>
-
-          <LocalPDFDownloadButton
-            mainDoc={mainDoc}
-            local={local}
-            user={user}
-            totalLivingSpace={totalLivingSpace}
-            costCategories={costCategories}
-            invoices={invoices}
-            contracts={contracts}
-            objekt={objekt}
-          />
-          <button>
-            <Image
-              width={0}
-              height={0}
-              sizes="100vw"
-              loading="lazy"
-              className="max-w-[35px] max-h-[35px] max-xl:max-w-6 max-xl:max-h-6 max-medium:max-w-8 max-medium:max-h-8"
-              src={gmail}
-              alt={"gmail_icon"}
-            />
-          </button>
-          {/* Three dots - visible only on desktop */}
-          <div className="max-medium:hidden">
-            <ThreeDotsButton
-              dialogAction="heating_bill_delete"
-              editLink={`${ROUTE_HEIZKOSTENABRECHNUNG}/${docType}/weitermachen/${docID}/abrechnungszeitraum`}
-            />
-          </div>
-        </div>
-      </div>
+      <HeatingBillActionButtons
+        objektId={id}
+        localId={item.id ?? ""}
+        docId={docID ?? ""}
+        previewHref={`${ROUTE_HEIZKOSTENABRECHNUNG}/${docType}/${id}/${docID}/results/${item.id}/preview`}
+        editLink={`${ROUTE_HEIZKOSTENABRECHNUNG}/${docType}/weitermachen/${docID}/abrechnungszeitraum`}
+        docType={docType}
+      />
     </div>
   );
 }


### PR DESCRIPTION
# Heizkostenabrechnung: Async Batch PDF Generation & Download Flow

## What Was Changed

### New API Endpoints
- **`POST /api/generate-heating-bills-batch`** – Generates heating bill PDFs for all locals in a building. Accepts `{ objektId, docId }`, fetches locals, computes the heating bill model once, renders one PDF, and uploads it to Supabase Storage for each local.
- **`POST /api/download-heating-bill`** – Returns a presigned URL for an existing heating bill PDF. Accepts `{ objektId, localId, docId }`, constructs the storage path, and returns `{ presignedUrl }` or 404 if the PDF does not exist.

### Modified Components
- **`SaveCostButton`** – When "Weiter" is clicked in the objektauswahl (building-level) heizkostenabrechnung flow, triggers a fire-and-forget `fetch` to the batch generation endpoint before redirecting to results. Does not block navigation.
- **`LocalPDFDownloadButton`** – Now calls `/api/download-heating-bill` first; on 404, falls back to `/api/generate-heating-bill` (preserves localauswahl on-demand generation). Props simplified from full preview props to `{ objektId, localId, docId }`.
- **`ObjekteObjektItemHeatingBillDocResult`** – Replaced inline action buttons (preview link, download, email) with a new client component. Removed heavy server-side data fetches that were only used for download.
- **`ObjekteLocalItemHeatingBillDocResult`** – Same `LocalPDFDownloadButton` prop changes and fetch removals.
- **`AdminObjekteLocalItemHeatingBillDocResult`** – Same `LocalPDFDownloadButton` prop changes and fetch removals.

### New Component
- **`HeatingBillActionButtons`** – Client component that polls `/api/download-heating-bill` for PDF readiness. When the PDF is not yet generated, disables the preview link, download button, and email button with `opacity-50` and `pointer-events-none`, and shows tooltip "Wird generiert..." on hover. Polls every 5 seconds until the PDF exists.

---

## Why It Was Changed

Previously, when users clicked "Weiter" on the umlageschlüssel page for heizkostenabrechnung (objektauswahl), they were redirected to a results page listing all locals in the building. Each download button generated a PDF on-demand, which caused slow first-time downloads and repeated computation.

This change improves the experience by:
1. **Async batch generation** – PDFs are generated for all locals in the background when "Weiter" is clicked, so they are ready when the user navigates to results.
2. **Separate download endpoint** – Downloads use presigned URLs for pre-generated PDFs instead of generating on each click.
3. **Clear feedback during generation** – While PDFs are still being generated, action buttons are disabled with a "Wird generiert..." tooltip so users know to wait.
4. **Backward compatibility** – The localauswahl (single-local) flow still works; it falls back to on-demand generation when the download endpoint returns 404.

---

## Impact on CI, Deployments, or Infrastructure

- **No CI changes** – No new scripts, linters, or test config.
- **No deployment changes** – Standard Next.js API routes; no new env vars or runtime requirements.
- **Supabase Storage** – Continues to use the existing `documents` bucket. Storage path pattern: `{userId}/{objektId}/{localId}/heating-bill_{docId}.pdf`.
- **Serverless function duration** – The batch endpoint may run longer for buildings with many locals; ensure your platform’s function timeout (e.g. Vercel’s default 10–60s) is sufficient for large buildings.
- **Client-side** – Fire-and-forget fetch uses `keepalive: true` to improve delivery when the user navigates away quickly.

---

## Required Follow-Up Actions

1. **Monitor batch duration** – For buildings with many locals (e.g. 50+), verify the batch endpoint completes before any function timeout. Consider a background job or queue if timeouts become an issue.
2. **Optional optimization** – The batch endpoint reuses one PDF buffer for all locals (same content). If per-local personalization is added to the PDF model in the future, each local would need its own render.
