### PR TITLE
Add tenant invite email template for Make.com integration

### DIFF
--- a/src/app/api/email-preview/route.ts
+++ b/src/app/api/email-preview/route.ts
@@ -1,14 +1,28 @@
 // src/app/api/email-preview/route.ts
-import { renderEmailByTemplate } from '@/utils/email/renderEmail';
+import { renderEmailByTemplate, EmailTemplateKey } from '@/utils/email/renderEmail';
 import { NextResponse } from 'next/server';
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const template = searchParams.get('template') as any;
+  const template = searchParams.get('template') as EmailTemplateKey;
 
-  const html = await renderEmailByTemplate(template, {
+  // Build props based on template type
+  let props: Record<string, string> = {
     userFirstName: 'Kgothatso Theko',
-  });
+  };
+
+  // Handle tenantInvite template with dynamic props
+  if (template === 'tenantInvite') {
+    const setupURL = searchParams.get('setupURL');
+    const name = searchParams.get('name');
+    
+    props = {
+      ...(setupURL && { setupURL }),
+      ...(name && { name }),
+    };
+  }
+
+  const html = await renderEmailByTemplate(template, props);
 
   return new NextResponse(html, {
     headers: { 'Content-Type': 'text/html' },

--- a/src/components/emails/TenantInviteEmail.tsx
+++ b/src/components/emails/TenantInviteEmail.tsx
@@ -1,0 +1,99 @@
+// src/components/emails/TenantInviteEmail.tsx
+import { Section, Text, Button, Row, Column, Img } from '@react-email/components';
+import { EmailLayout } from './EmailLayout';
+import { buildQrCodeUrl } from './constants';
+
+interface TenantInviteEmailProps {
+  setupURL?: string;
+  name?: string;
+}
+
+export const TenantInviteEmail = ({ 
+  setupURL = "https://heidisystems.com/mieter/setup", 
+  name = "Mieter" 
+}: TenantInviteEmailProps) => {
+  const qrCodeUrl = buildQrCodeUrl(setupURL, 150);
+
+  return (
+    <EmailLayout previewText="Zugang zu Ihrem Mieterportal" variant="light">
+      <Section className="bg-white border border-solid border-[#E5E5E5] rounded-[24px] p-[40px] mt-[13px]">
+        
+        {/* Greeting */}
+        <Text className="text-[#1A1A1A] text-[20px] font-semibold m-0 mb-[20px]">
+          Hallo {name},
+        </Text>
+        
+        {/* Introduction */}
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[24px]">
+          Sie können ab sofort Ihr persönliches <strong>Mieterportal</strong> nutzen.
+        </Text>
+
+        {/* Features List */}
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[24px]">
+          Dort finden Sie unter anderem:
+        </Text>
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[8px] pl-[16px]">
+          • Ihren Verbrauch
+        </Text>
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[8px] pl-[16px]">
+          • Abrechnungsinformationen
+        </Text>
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[32px] pl-[16px]">
+          • wichtige Dokumente
+        </Text>
+
+        {/* QR Code Section */}
+        <Section className="text-center mb-[32px] border border-solid border-[#E5E5E5] rounded-[24px] p-[30px]">
+          <Text className="text-[#1A1A1A] text-[16px] font-semibold mb-[16px]">
+            Scannen Sie einfach den QR-Code:
+          </Text>
+          
+          <Row>
+            <Column align="center">
+              <div className="inline-block bg-white p-[15px] rounded-[12px]">
+                <Img
+                  src={qrCodeUrl}
+                  alt="Mieterportal QR Code"
+                  width={150}
+                  height={150}
+                />
+              </div>
+            </Column>
+          </Row>
+        </Section>
+
+        {/* Alternative Button */}
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[16px] text-center">
+          Alternativ können Sie den Zugang auch über diesen Link öffnen:
+        </Text>
+
+        <Section className="text-center mb-[32px]">
+          <Button
+            href={setupURL}
+            className="rounded-full bg-[#BDEAA4] text-[#2F6121] text-[16px] font-bold no-underline text-center px-[32px] py-[12px]"
+          >
+            Mieterzugang
+          </Button>
+        </Section>
+
+        {/* Password Note */}
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[24px]">
+          Falls Sie noch kein Passwort vergeben haben, folgen Sie bitte den Anweisungen auf der Setup-Seite.
+        </Text>
+
+        {/* Support Note */}
+        <Text className="text-[#404040] text-[16px] leading-[24px] m-0 mb-[24px]">
+          Bei Fragen helfen wir Ihnen gerne weiter.
+        </Text>
+
+        {/* Closing */}
+        <Text className="text-[#404040] text-[16px] leading-[24px] mt-[24px] m-0">
+          Freundliche Grüße,<br />
+          <span className="underline">Ihr Heidi Systems Team</span>
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+};
+
+export default TenantInviteEmail;

--- a/src/utils/email/renderEmail.tsx
+++ b/src/utils/email/renderEmail.tsx
@@ -26,12 +26,14 @@ import HeidiPremiumTrial from '@/components/emails/HeidiPremiumTrial';
 import HeidiYearlyReview from '@/components/emails/HeidiYearlyReview';
 import CreatorCampEmail from '@/components/emails/CreatorCampEmail';
 import HeidiConfirmEmail from '@/components/emails/HediConfirmEmail';
+import TenantInviteEmail from '@/components/emails/TenantInviteEmail';
 
 const templates = {
   premiumTrial: HeidiPremiumTrial,
   yearlyReview: HeidiYearlyReview,
-   creatorCamp: CreatorCampEmail,
-   confirmEmail: HeidiConfirmEmail,
+  creatorCamp: CreatorCampEmail,
+  confirmEmail: HeidiConfirmEmail,
+  tenantInvite: TenantInviteEmail,
 };
 
 export type EmailTemplateKey = keyof typeof templates;


### PR DESCRIPTION
## Summary
- Create `TenantInviteEmail.tsx` with dynamic `name` and `setupURL` props
- Update `/api/email-preview` to accept `name` and `setupURL` query params
- Register `tenantInvite` template in `renderEmail.tsx`

## Approach
Followed KG's existing email template patterns (`HeidiConfirmEmail.tsx`, `SharedQrLoginSection.tsx`) and Paul's approved layout/content. QR code generated dynamically using the same `buildQrCodeUrl()` utility.

## Usage
Denis's Make.com workflow calls