### PR TITLE
feat: Add default value to Cost types

### DIFF
--- a/src/components/Admin/Docs/CostTypes/CostTypeSelectItem.tsx
+++ b/src/components/Admin/Docs/CostTypes/CostTypeSelectItem.tsx
@@ -46,7 +46,7 @@ export default function CostTypeSelectItem({ type }: CostTypeItemProps) {
           label=""
           placeholder=""
           options={["Verbrauch", "m2 Wohnfläche", "Wohneinheiten"]}
-          selectedValue={type.allocation_key ? type.allocation_key : ""}
+          selectedValue={type.allocation_key ? type.allocation_key : "Verbrauch"}
           onChange={(val) =>
             updateAllocationKey(
               type.type,


### PR DESCRIPTION
## Changes

### Modified: 
- src/components/Admin/Docs/CostTypes/CostTypeSelectItem.tsx
   - Updated the Select component's selectedValue prop to fallback to "Verbrauch" when type.allocation_key is null or undefined.

### Verification
- Validated that the dropdown now correctly displays "Verbrauch" by default when adding or viewing cost types without a pre-set allocation key.
- Confirmed that this change applies to all specialized Heizkostenabrechnung forms reusing this component (e.g., 
AdminUmlageschlüsselHeatObjektauswahlForm).