### PR TITLE
feat: Refine heating device type classification to distinguish HCAs, …

### DIFF
--- a/src/app/api/heating-bill/_lib/compute.ts
+++ b/src/app/api/heating-bill/_lib/compute.ts
@@ -28,6 +28,7 @@ import { getHkvoFactor } from "./constants";
 
 const HEAT_DEVICE_TYPES = [
   "Heat",
+  "HCA",
   "Wärmemengenzähler",
   "Heizkostenverteiler",
   "WMZ Rücklauf",
@@ -250,28 +251,58 @@ export function computeHeatingBill(
   const coldWaterDevicesForLocal = unitReadingsResult.deviceRows.coldWater.filter((r) =>
     belongsToLocal(r.deviceNumber)
   );
-  if (
-    process.env.NODE_ENV !== "production" &&
-    (raw.localMeters?.length ?? 0) > 0 &&
-    deviceIdToLocalId.size === 0
-  ) {
+  // Diagnostic logging: always log device pipeline counts for troubleshooting
+  const allDeviceRowCount =
+    unitReadingsResult.deviceRows.heat.length +
+    unitReadingsResult.deviceRows.warmWater.length +
+    unitReadingsResult.deviceRows.coldWater.length;
+  const localDeviceRowCount =
+    heatingDevicesForLocal.length +
+    warmWaterDevicesForLocal.length +
+    coldWaterDevicesForLocal.length;
+
+  if ((raw.localMeters?.length ?? 0) > 0 && deviceIdToLocalId.size === 0) {
     console.warn("[HeatingBill] local meter mapping is empty after normalization", {
       localMetersCount: raw.localMeters.length,
       targetLocalId: targetLocalId ?? null,
     });
   }
-  if (
-    process.env.NODE_ENV !== "production" &&
-    targetLocalId &&
-    unitReadingsResult.deviceRows.heat.length + unitReadingsResult.deviceRows.warmWater.length + unitReadingsResult.deviceRows.coldWater.length > 0 &&
-    heatingDevicesForLocal.length + warmWaterDevicesForLocal.length + coldWaterDevicesForLocal.length === 0
-  ) {
+  if (allDeviceRowCount > 0 && localDeviceRowCount === 0 && targetLocalId) {
+    // Log unmatched devices to identify why filtering dropped everything
+    const unmatchedDevices = [
+      ...unitReadingsResult.deviceRows.heat,
+      ...unitReadingsResult.deviceRows.warmWater,
+      ...unitReadingsResult.deviceRows.coldWater,
+    ].map((r) => ({
+      deviceNumber: r.deviceNumber,
+      normalizedId: normalizeDeviceId(r.deviceNumber),
+      mappedLocalId: deviceIdToLocalId.get(normalizeDeviceId(r.deviceNumber)) ?? "NOT_FOUND",
+    }));
     console.warn("[HeatingBill] no device rows matched target local after filtering", {
       targetLocalId,
       allHeatDevices: unitReadingsResult.deviceRows.heat.length,
       allWarmWaterDevices: unitReadingsResult.deviceRows.warmWater.length,
       allColdWaterDevices: unitReadingsResult.deviceRows.coldWater.length,
+      localHeatDevices: heatingDevicesForLocal.length,
+      localWarmWaterDevices: warmWaterDevicesForLocal.length,
+      localColdWaterDevices: coldWaterDevicesForLocal.length,
       mappedMeters: deviceIdToLocalId.size,
+      unmatchedDevices: unmatchedDevices.slice(0, 10), // limit to 10 for log readability
+    });
+  }
+  // Log device type distribution from raw readings for debugging
+  if (raw.meterReadings.length > 0 && allDeviceRowCount === 0) {
+    const typeCounts: Record<string, number> = {};
+    for (const r of raw.meterReadings) {
+      const dt = String(r["Device Type"] ?? "unknown");
+      typeCounts[dt] = (typeCounts[dt] ?? 0) + 1;
+    }
+    console.warn("[HeatingBill] RPC returned readings but no device rows were produced", {
+      totalReadings: raw.meterReadings.length,
+      deviceTypeCounts: typeCounts,
+      heatTypeFilter: HEAT_DEVICE_TYPES,
+      warmWaterTypeFilter: WARM_WATER_DEVICE_TYPES,
+      coldWaterTypeFilter: COLD_WATER_DEVICE_TYPES,
     });
   }
 

--- a/src/app/api/heating-bill/_lib/readings.ts
+++ b/src/app/api/heating-bill/_lib/readings.ts
@@ -51,8 +51,10 @@ function getDeviceId(r: MeterReadingType): string {
 
 function getDeviceType(r: MeterReadingType): string {
   const dt = r["Device Type"];
-  if (dt === "Heat" || dt === "Wärmemengenzähler" || dt === "Heizkostenverteiler" || dt === "WMZ Rücklauf")
+  if (dt === "Heat" || dt === "Wärmemengenzähler" || dt === "WMZ Rücklauf")
     return "Wärmezähler";
+  if (dt === "HCA" || dt === "Heizkostenverteiler")
+    return "Heizkostenverteiler";
   if (dt === "WWater" || dt === "Warmwasserzähler") return "Warmwasserzähler";
   if (dt === "Water" || dt === "Kaltwasserzähler") return "Kaltwasserzähler";
   return String(dt ?? "Unbekannt");


### PR DESCRIPTION
# PR: Fix Missing Meter IDs in Dynamic PDF

## What was changed

### `src/app/api/heating-bill/_lib/compute.ts`
- **Added `"HCA"` to `HEAT_DEVICE_TYPES` filter array** — HCA (Heizkostenverteiler / heat cost allocator) readings were being fetched from the database via the Supabase RPC but silently dropped by the device type filter before reaching the PDF consumption table.
- **Upgraded diagnostic logging** — removed the `NODE_ENV !== "production"` guard so logs always fire. When device rows are filtered out, the logger now prints:
  - Per-device mapping details (device number, normalized ID, mapped local ID)
  - Device type distribution from raw RPC readings
  - This makes production issues diagnosable without needing to reproduce locally.

### `src/app/api/heating-bill/_lib/readings.ts`
- **Updated `getDeviceType()` mapping** — `"HCA"` now maps to the display label `"Heizkostenverteiler"` instead of falling through to the raw code `"HCA"`. True heat meters (`"Heat"`, `"Wärmemengenzähler"`, `"WMZ Rücklauf"`) continue to map to `"Wärmezähler"`.

## Why it was changed

Apartments with HCA-type consumption meters were generating PDFs with **empty consumption tables** — no meter IDs, no readings, no consumption values on page 4 of the heating bill.

**Root cause:** The `data-fetcher.ts` RPC call correctly requests `"HCA"` as a device type, but `compute.ts` did not include `"HCA"` in its `HEAT_DEVICE_TYPES` filter. This caused all HCA readings to be silently excluded at the filtering stage in `computeHeatingBill()`, resulting in empty `heatingDevices` arrays in the PDF model.

This was confirmed by:
1. A DB query showing `device_id` = `meter_number` for all affected meters (ruling out ID format mismatch)
2. Tracing the full data pipeline from RPC → readings → compute → PDF render

## Impact on CI, Deployments, or Infrastructure

- **CI:** No impact. TypeScript compilation passes. No new dependencies added.
- **Deployments:** This is a backend computation change only. No database migrations, no schema changes, no env var changes required.
- **Infrastructure:** The enhanced logging will produce additional `console.warn` output in production when device filtering issues occur. This is intentional for observability and does not affect performance.

## Required Follow-up Actions

- **HCA consumption units:** HCA devices report consumption in arbitrary "units", not Wh. The current pipeline divides by 1,000,000 (Wh → MWh conversion), which is incorrect for HCA. This is a **known separate issue** tracked from a prior investigation and should be addressed in a follow-up PR to ensure HCA consumption values display correctly.
- **Verification:** Generate a heating bill PDF for an affected user (e.g. `brandenburg@carter-benson.com`) and confirm all meters appear in the consumption tables (Heizung, Warmwasser, Kaltwasser sections).
