### PR TITLE
feat: Categorize metering device rental costs into heating, warm wate…

### DIFF
--- a/src/app/api/heating-bill/_lib/compute.ts
+++ b/src/app/api/heating-bill/_lib/compute.ts
@@ -152,9 +152,8 @@ export function computeHeatingBill(
     : readingsResult.totalHeatMwh;
   const heatingMwh = heatingConsumptionValue;
 
-  const combinedDeviceRental = costAgg.meteringDeviceRentalTotal || 0;
-  const wwDeviceRental = combinedDeviceRental;
-  const heatingDeviceRental = 0;
+  const wwDeviceRental = costAgg.wwDeviceRentalTotal || 0;
+  const heatingDeviceRental = costAgg.heatingDeviceRentalTotal || 0;
 
   const livingSpaceShare = Number(
     raw.mainDoc.living_space_share ?? 30

--- a/src/app/api/heating-bill/_lib/costs.ts
+++ b/src/app/api/heating-bill/_lib/costs.ts
@@ -55,7 +55,9 @@ export type CostAggregation = {
 
   coldWaterInvoices: HeatingInvoiceType[];
   coldWaterTotal: number;
-  meteringDeviceRentalTotal: number;
+  heatingDeviceRentalTotal: number;  // Heizkostenverteiler, Wärmemengenzähler, Kältezähler
+  wwDeviceRentalTotal: number;       // Warmwasserzähler
+  coldWaterDeviceRentalTotal: number; // Kaltwasserzähler
 };
 
 /** Round to 2 decimals for currency */
@@ -118,7 +120,9 @@ export function aggregateInvoiceCosts(
 
   const coldWaterInvoices: HeatingInvoiceType[] = [];
   let coldWaterTotal = 0;
-  let meteringDeviceRentalTotal = 0;
+  let heatingDeviceRentalTotal = 0;
+  let wwDeviceRentalTotal = 0;
+  let coldWaterDeviceRentalTotal = 0;
 
   const costTypeMap = (ct: string | null | undefined): string =>
     (ct ?? "").toLowerCase().replace(/\s/g, "_");
@@ -130,8 +134,25 @@ export function aggregateInvoiceCosts(
     const label =
       inv.purpose || inv.document_name || `Rechnung ${inv.id?.slice(0, 8) ?? ""}`;
 
-    if (ct === "metering_device_rental" || ct === "metering_service_costs") {
-      meteringDeviceRentalTotal += amount;
+    if (ct === "metering_service_costs") {
+      heatingDeviceRentalTotal += amount;
+      continue;
+    }
+
+    if (ct === "metering_device_rental") {
+      const purpose = (inv.purpose ?? "").trim();
+      if (purpose === "Warmwasserzähler") {
+        wwDeviceRentalTotal += amount;
+      } else if (purpose === "Kaltwasserzähler") {
+        coldWaterDeviceRentalTotal += amount;
+        coldWaterInvoices.push(inv);
+        coldWaterTotal += amount;
+        distributionCostItems.push({ label, amount, amountFormatted: formatEuro(amount) });
+        distributionCostTotal += amount;
+      } else {
+        // Heizkostenverteiler, Wärmemengenzähler, Kältezähler, unspecified → Heat
+        heatingDeviceRentalTotal += amount;
+      }
       continue;
     }
 
@@ -217,6 +238,8 @@ export function aggregateInvoiceCosts(
     grandTotal,
     coldWaterInvoices,
     coldWaterTotal,
-    meteringDeviceRentalTotal: round2(meteringDeviceRentalTotal),
+    heatingDeviceRentalTotal: round2(heatingDeviceRentalTotal),
+    wwDeviceRentalTotal: round2(wwDeviceRentalTotal),
+    coldWaterDeviceRentalTotal: round2(coldWaterDeviceRentalTotal),
   };
 }


### PR DESCRIPTION
# fix: Correct cost category mapping for metering device rentals

## What was changed

Two files in the heating bill aggregation pipeline were updated:

### `src/app/api/heating-bill/_lib/costs.ts`
- Replaced the single `meteringDeviceRentalTotal` accumulator with three purpose-specific buckets: `heatingDeviceRentalTotal`, `wwDeviceRentalTotal`, and `coldWaterDeviceRentalTotal`
- The aggregation loop now inspects `inv.purpose` to route each `metering_device_rental` invoice to the correct bucket:
  - `Heizkostenverteiler`, `Wärmemengenzähler`, `Kältezähler` (and unspecified) → `heatingDeviceRentalTotal`
  - `Warmwasserzähler` → `wwDeviceRentalTotal`
  - `Kaltwasserzähler` → `coldWaterDeviceRentalTotal` (also appended to `coldWaterInvoices` and `distributionCostItems` so it surfaces in the cold water section of the PDF)
- `metering_service_costs` (Messdienstkosten) is now also routed to `heatingDeviceRentalTotal` instead of the old combined pool

### `src/app/api/heating-bill/_lib/compute.ts`
- `heatingDeviceRental` now reads from `costAgg.heatingDeviceRentalTotal` (was hardcoded `0`)
- `wwDeviceRental` now reads from `costAgg.wwDeviceRentalTotal` (was the entire combined pool)
- Removed the intermediate `combinedDeviceRental` variable

## Why it was changed

The previous implementation had two compounding bugs:

1. **All `metering_device_rental` costs were bucketed together** regardless of the device sub-type stored in `inv.purpose`. The `purpose` field — which holds the user-selected option (e.g. "Heizkostenverteiler") — was never consulted during aggregation.

2. **The combined pool was then routed entirely to warm water** (`wwDeviceRental = combinedDeviceRental`, `heatingDeviceRental = 0`). This meant rental costs for heat distribution devices (Heizkostenverteiler, Wärmemengenzähler, Kältezähler) and even general metering service costs appeared in the warm water cost section instead of the heating cost section, and cold water meter rentals (Kaltwasserzähler) were missing from the cold water section entirely.

The correct mapping per device sub-type is:

| Device (purpose) | Category |
|---|---|
| Heizkostenverteiler | Heat |
| Wärmemengenzähler | Heat |
| Kältezähler | Heat |
| Warmwasserzähler | Warm Water |
| Kaltwasserzähler | Cold Water |

## Impact on CI, deployments, or infrastructure

- **No schema changes** — no database migrations required
- **No API contract changes** — the POST `/api/heating-bill/generate/batch` response shape is unchanged
- **PDF output will change** for any building that has `metering_device_rental` invoices with a `purpose` value set: cost amounts will now appear in the correct sections of the generated heating bill PDF
- **No environment variable or infrastructure changes** required

## Required follow-up actions

- [ ] Regenerate heating bill PDFs for any billing periods where `metering_device_rental` invoices were already processed — existing PDFs will reflect the incorrect categorisation
- [ ] Verify with a test building that has all five device sub-types present to confirm PDF output matches expected cost sections
- [ ] Consider adding a unit test for `aggregateInvoiceCosts` covering the `metering_device_rental` routing logic to prevent regression
