### PR TITLE
feat: Implement pending heating bill PDF status, filter recently crea…

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -951,15 +951,20 @@ export async function getCurrentUserDocuments(): Promise<any[]> {
     .map(doc => doc.related_id);
 
   let heatingBillObjekts: Record<string, string> = {};
+  const lockedHbIds = new Set<string>();
   if (heatingBillIds.length > 0) {
     const heatingBills = await database
-      .select({ id: heating_bill_documents.id, objekt_id: heating_bill_documents.objekt_id })
+      .select({ id: heating_bill_documents.id, objekt_id: heating_bill_documents.objekt_id, created_at: heating_bill_documents.created_at })
       .from(heating_bill_documents)
       .where(inArray(heating_bill_documents.id, heatingBillIds));
 
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
     heatingBillObjekts = heatingBills.reduce((acc, bill) => {
       if (bill.objekt_id) {
         acc[bill.id] = bill.objekt_id;
+      }
+      if (!isSuperAdmin && bill.created_at && new Date(bill.created_at) > twentyFourHoursAgo) {
+        lockedHbIds.add(bill.id);
       }
       return acc;
     }, {} as Record<string, string>);
@@ -983,14 +988,16 @@ export async function getCurrentUserDocuments(): Promise<any[]> {
     }, {} as Record<string, string>);
   }
 
-  return userDocuments.map(doc => ({
-    ...doc,
-    objekt_id: doc.related_type === "heating_bill"
-      ? heatingBillObjekts[doc.related_id] || null
-      : doc.related_type === "operating_costs"
-        ? operatingCostObjekts[doc.related_id] || null
-        : null
-  }));
+  return userDocuments
+    .filter(doc => !(doc.related_type === "heating_bill" && lockedHbIds.has(doc.related_id)))
+    .map(doc => ({
+      ...doc,
+      objekt_id: doc.related_type === "heating_bill"
+        ? heatingBillObjekts[doc.related_id] || null
+        : doc.related_type === "operating_costs"
+          ? operatingCostObjekts[doc.related_id] || null
+          : null
+    }));
 }
 
 export async function getAllUsers(permissions: string[]): Promise<UserType[]> {
@@ -1433,19 +1440,25 @@ export async function getDocumentsByRelatedIds(
  */
 export async function getDocumentsByObjektIds(
   objektIds: string[],
-  includeHistory: boolean = false
+  includeHistory: boolean = false,
+  viewerIsSuperAdmin: boolean = false
 ): Promise<any[]> {
   if (objektIds.length === 0) return [];
 
   // Find all heating bill doc IDs for these objekts
   const hbDocs = await database
-    .select({ id: heating_bill_documents.id, objekt_id: heating_bill_documents.objekt_id })
+    .select({ id: heating_bill_documents.id, objekt_id: heating_bill_documents.objekt_id, created_at: heating_bill_documents.created_at })
     .from(heating_bill_documents)
     .where(inArray(heating_bill_documents.objekt_id, objektIds));
 
   const hbObjektMap: Record<string, string> = {};
+  const lockedHbIds = new Set<string>();
+  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
   for (const hb of hbDocs) {
     if (hb.objekt_id) hbObjektMap[hb.id] = hb.objekt_id;
+    if (!viewerIsSuperAdmin && hb.created_at && new Date(hb.created_at) > twentyFourHoursAgo) {
+      lockedHbIds.add(hb.id);
+    }
   }
 
   // Find all operating cost doc IDs for these objekts
@@ -1479,10 +1492,12 @@ export async function getDocumentsByObjektIds(
     .where(and(...conditions))
     .orderBy(documents.created_at);
 
-  return allDocs.map((doc) => ({
-    ...doc,
-    objekt_id: hbObjektMap[doc.related_id] ?? ocObjektMap[doc.related_id] ?? null,
-  }));
+  return allDocs
+    .filter(doc => !lockedHbIds.has(doc.related_id))
+    .map((doc) => ({
+      ...doc,
+      objekt_id: hbObjektMap[doc.related_id] ?? ocObjektMap[doc.related_id] ?? null,
+    }));
 }
 
 /**

--- a/src/app/(admin)/admin/[user_id]/dokumente/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/dokumente/page.tsx
@@ -3,6 +3,10 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import DokumenteLayout from "@/components/Admin/Docs/DokumenteLayout/DokumenteLayout";
 import { ROUTE_ADMIN } from "@/routes/routes";
+import { supabaseServer } from "@/utils/supabase/server";
+import database from "@/db";
+import { users } from "@/db/drizzle/schema";
+import { eq } from "drizzle-orm";
 
 interface DokumentePageProps {
   params: Promise<{
@@ -16,13 +20,24 @@ export default async function DokumentePage({ params, searchParams }: DokumenteP
   const resolvedSearchParams = await searchParams;
   const includeHistory = resolvedSearchParams?.includeHistory === 'true';
 
+  const supabase = await supabaseServer();
+  const { data: { user: viewer } } = await supabase.auth.getUser();
+  let viewerIsSuperAdmin = false;
+  if (viewer) {
+    const [viewerData] = await database
+      .select({ permission: users.permission })
+      .from(users)
+      .where(eq(users.id, viewer.id));
+    viewerIsSuperAdmin = viewerData?.permission === "super_admin";
+  }
+
   const objektsWithLocals = await getObjektsWithLocalsByUserID(user_id);
 
   // Get documents by objekt IDs (avoids user_id mismatch in admin context)
   const objektIds = objektsWithLocals
     .map((o) => o.id)
     .filter((id): id is string => Boolean(id));
-  const documents = await getDocumentsByObjektIds(objektIds, includeHistory);
+  const documents = await getDocumentsByObjektIds(objektIds, includeHistory, viewerIsSuperAdmin);
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none max-medium:overflow-y-auto grid grid-rows-[auto_1fr]">

--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx
@@ -9,8 +9,9 @@ import AdminObjekteLocalItemHeatingBillDocResult from "@/components/Admin/Objekt
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
 import { supabaseServer } from "@/utils/supabase/server";
 import database from "@/db";
-import { users } from "@/db/drizzle/schema";
+import { users, heating_bill_documents } from "@/db/drizzle/schema";
 import { eq } from "drizzle-orm";
+import HeatingBillPDFPendingModal from "@/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal";
 
 export default async function ResultLocalPDF({
   params,
@@ -35,6 +36,13 @@ export default async function ResultLocalPDF({
       .where(eq(users.id, currentUser.id));
     isSuperAdmin = userData?.permission === "super_admin";
   }
+
+  const [hbDoc] = await database
+    .select({ created_at: heating_bill_documents.created_at })
+    .from(heating_bill_documents)
+    .where(eq(heating_bill_documents.id, doc_id));
+  const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
+    new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   const [localData, documentsByLocalId, contracts] = await Promise.all([
     getLocalById(local_id),
@@ -76,6 +84,7 @@ export default async function ResultLocalPDF({
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none grid grid-rows-[auto_1fr]">
+      <HeatingBillPDFPendingModal isOpen={isPdfPending} />
       <Breadcrumb
         backTitle="Objekte"
         link={`${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}`}
@@ -89,7 +98,7 @@ export default async function ResultLocalPDF({
           item={localData}
           docType="localauswahl"
           docID={doc_id}
-          tenantDocuments={tenantDocuments}
+          tenantDocuments={isPdfPending ? [] : tenantDocuments}
           isSuperAdmin={isSuperAdmin}
         />
       </ContentWrapper>

--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
@@ -12,8 +12,9 @@ import { buildLocalName } from "@/utils";
 import type { UnitType } from "@/types";
 import { supabaseServer } from "@/utils/supabase/server";
 import database from "@/db";
-import { users } from "@/db/drizzle/schema";
+import { users, heating_bill_documents } from "@/db/drizzle/schema";
 import { eq } from "drizzle-orm";
+import HeatingBillPDFPendingModal from "@/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal";
 
 const ALLOWED_HEATING_BILL_USAGE_TYPES = new Set<UnitType>([
   "residential",
@@ -41,6 +42,13 @@ export default async function ResultLocalPDF({
       .where(eq(users.id, currentUser.id));
     isSuperAdmin = userData?.permission === "super_admin";
   }
+
+  const [hbDoc] = await database
+    .select({ created_at: heating_bill_documents.created_at })
+    .from(heating_bill_documents)
+    .where(eq(heating_bill_documents.id, doc_id));
+  const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
+    new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   let locals = (await getRelatedLocalsByObjektId(objekt_id)).filter((local) =>
     ALLOWED_HEATING_BILL_USAGE_TYPES.has(local.usage_type as UnitType)
@@ -125,6 +133,7 @@ export default async function ResultLocalPDF({
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none grid grid-rows-[auto_1fr]">
+      <HeatingBillPDFPendingModal isOpen={isPdfPending} />
       <Breadcrumb
         backTitle="Objekte"
         link={`${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}`}
@@ -156,7 +165,7 @@ export default async function ResultLocalPDF({
                 docType="objektauswahl"
                 docID={doc_id}
                 status={status}
-                tenantDocuments={tenantDocsByLocalId[local.id ?? ""] ?? []}
+                tenantDocuments={isPdfPending ? [] : (tenantDocsByLocalId[local.id ?? ""] ?? [])}
                 isSuperAdmin={isSuperAdmin}
               />
             ))

--- a/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx
@@ -7,6 +7,11 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import ObjekteLocalItemHeatingBillDocResult from "@/components/Admin/ObjekteLocalItem/ObjekteLocalItemHeatingBillDocResult";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
+import HeatingBillPDFPendingModal from "@/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal";
+import { supabaseServer } from "@/utils/supabase/server";
+import database from "@/db";
+import { users, heating_bill_documents } from "@/db/drizzle/schema";
+import { eq } from "drizzle-orm";
 
 export default async function ResultLocalPDF({
   params,
@@ -14,6 +19,24 @@ export default async function ResultLocalPDF({
   params: Promise<{ objekt_id: string; local_id: string; doc_id: string }>;
 }) {
   const { objekt_id, local_id, doc_id } = await params;
+
+  const supabase = await supabaseServer();
+  const { data: { user: currentUser } } = await supabase.auth.getUser();
+  let isSuperAdmin = false;
+  if (currentUser) {
+    const [userData] = await database
+      .select({ permission: users.permission })
+      .from(users)
+      .where(eq(users.id, currentUser.id));
+    isSuperAdmin = userData?.permission === "super_admin";
+  }
+
+  const [hbDoc] = await database
+    .select({ created_at: heating_bill_documents.created_at })
+    .from(heating_bill_documents)
+    .where(eq(heating_bill_documents.id, doc_id));
+  const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
+    new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   const [localData, documentsByLocalId, contracts] = await Promise.all([
     getLocalById(local_id),
@@ -54,6 +77,7 @@ export default async function ResultLocalPDF({
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none max-medium:overflow-y-auto grid grid-rows-[auto_1fr]">
+      <HeatingBillPDFPendingModal isOpen={isPdfPending} />
       <Breadcrumb
         backTitle="Objekte"
         link={ROUTE_HEIZKOSTENABRECHNUNG}
@@ -66,7 +90,7 @@ export default async function ResultLocalPDF({
           item={localData}
           docID={doc_id}
           docType="localauswahl"
-          tenantDocuments={tenantDocuments}
+          tenantDocuments={isPdfPending ? [] : tenantDocuments}
         />
       </ContentWrapper>
     </div>

--- a/src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
@@ -10,6 +10,11 @@ import SearchControls from "@/components/Admin/SearchControls";
 import { buildLocalName } from "@/utils";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
 import type { UnitType } from "@/types";
+import HeatingBillPDFPendingModal from "@/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal";
+import { supabaseServer } from "@/utils/supabase/server";
+import database from "@/db";
+import { users, heating_bill_documents } from "@/db/drizzle/schema";
+import { eq } from "drizzle-orm";
 
 const ALLOWED_HEATING_BILL_USAGE_TYPES = new Set<UnitType>([
   "residential",
@@ -25,6 +30,24 @@ export default async function ResultLocalPDF({
 }) {
   const { objekt_id, doc_id } = await params;
   const { search = "", sort = "asc" } = await searchParams;
+
+  const supabase = await supabaseServer();
+  const { data: { user: currentUser } } = await supabase.auth.getUser();
+  let isSuperAdmin = false;
+  if (currentUser) {
+    const [userData] = await database
+      .select({ permission: users.permission })
+      .from(users)
+      .where(eq(users.id, currentUser.id));
+    isSuperAdmin = userData?.permission === "super_admin";
+  }
+
+  const [hbDoc] = await database
+    .select({ created_at: heating_bill_documents.created_at })
+    .from(heating_bill_documents)
+    .where(eq(heating_bill_documents.id, doc_id));
+  const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
+    new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   let locals = (await getRelatedLocalsByObjektId(objekt_id)).filter((local) =>
     ALLOWED_HEATING_BILL_USAGE_TYPES.has(local.usage_type as UnitType)
@@ -112,6 +135,7 @@ export default async function ResultLocalPDF({
 
   return (
     <div className="py-6 px-9 max-medium:px-4 max-medium:py-4 h-[calc(100dvh-77px)] max-h-[calc(100dvh-77px)] max-xl:h-[calc(100dvh-53px)] max-xl:max-h-[calc(100dvh-53px)] max-medium:h-auto max-medium:max-h-none max-medium:overflow-y-auto grid grid-rows-[auto_1fr]">
+      <HeatingBillPDFPendingModal isOpen={isPdfPending} />
       <Breadcrumb
         backTitle="Objekte"
         link={ROUTE_HEIZKOSTENABRECHNUNG}
@@ -143,7 +167,7 @@ export default async function ResultLocalPDF({
                   docType="objektauswahl"
                   docID={doc_id}
                   status={status}
-                  tenantDocuments={tenantDocsByLocalId[local.id ?? ""] ?? []}
+                  tenantDocuments={isPdfPending ? [] : (tenantDocsByLocalId[local.id ?? ""] ?? [])}
                 />
               ))
             )}

--- a/src/app/(service)/fragebogen/page.tsx
+++ b/src/app/(service)/fragebogen/page.tsx
@@ -23,7 +23,7 @@ const formSchema = z.object({
       "über 800 Immobilien",
     ])
     .nullable(),
-  
+
   // Over50 Flow (51-800 & über 800 Immobilien) fields
   messdienstleister_count: z.number().min(1).optional(),
   zusammenarbeit_status: z
@@ -34,7 +34,7 @@ const formSchema = z.object({
     .enum(["Ja", "Nein"])
     .nullable()
     .optional(),
-  
+
   // Under50 Flow (1-50 Immobilien) fields
   wohnungen_count: z.number().min(1).optional(),
   funkzaehler_status: z
@@ -42,12 +42,12 @@ const formSchema = z.object({
     .nullable()
     .optional(),
   standort_schwerpunkt: z.string().optional().or(z.literal("")),
-  
+
   // Contact form fields (Q5 - Location)
   verwaltung_name: z.string().optional().or(z.literal("")),
   postleitzahl: z.string().optional().or(z.literal("")),
   ort: z.string().optional().or(z.literal("")),
-  
+
   // Contact form fields (Q6 - Personal)
   email: z.string().email("Bitte geben Sie eine gültige E-Mail-Adresse ein"),
   first_name: z.string().min(1, "Bitte füllen Sie dieses Feld aus"),
@@ -246,9 +246,8 @@ export default function FragebogenPage() {
               <span
                 key={step}
                 data-step-index={step}
-                className={`w-[50px] max-small:w-[30px] h-[1px] ${
-                  step <= activeStep ? "bg-green" : "bg-dark_green/10"
-                }`}
+                className={`w-[50px] max-small:w-[30px] h-[1px] ${step <= activeStep ? "bg-green" : "bg-dark_green/10"
+                  }`}
               ></span>
             ))}
             <span className="text-xs text-dark_text/20"> noch 4 min </span>
@@ -299,7 +298,7 @@ export default function FragebogenPage() {
                   const isUnder50Flow = propertyCategory === "1-50 Immobilien";
                   // Under50 flow submits on step 4, Over50 flow submits on step 5
                   const isSubmitStep = isUnder50Flow ? activeStep === 4 : activeStep === 5;
-                  
+
                   const handleClick = () => {
                     // Validate step 0 - property count is required
                     if (activeStep === 0 && !propertyCategory) {
@@ -309,7 +308,7 @@ export default function FragebogenPage() {
                     setStep0Error(false);
                     handleNextStep();
                   };
-                  
+
                   return (
                     <button
                       id="next-step"
@@ -329,7 +328,7 @@ export default function FragebogenPage() {
                   const lastStep = isUnder50Flow ? 4 : 5;
                   // Hide skip button on step 0 (required) and last step
                   if (activeStep === 0 || activeStep === lastStep) return null;
-                  
+
                   return (
                     <button
                       id="skip-step"

--- a/src/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal.tsx
+++ b/src/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { green_check_circle, close_dialog } from "@/static/icons";
+
+interface HeatingBillPDFPendingModalProps {
+  isOpen: boolean;
+}
+
+export default function HeatingBillPDFPendingModal({ isOpen }: HeatingBillPDFPendingModalProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const router = useRouter();
+
+  if (!isOpen || dismissed) return null;
+
+  return (
+    <div className="fixed inset-0 z-[1000] w-screen h-screen flex items-center justify-center bg-black/20 backdrop-blur-sm">
+      <div className="w-full max-w-[576px] max-small:w-[85%] bg-white rounded flex flex-col overflow-hidden">
+        <div className="px-9 py-4 flex-shrink-0">
+          <button
+            onClick={() => setDismissed(true)}
+            className="cursor-pointer flex items-center justify-center mr-0 ml-auto border-none bg-transparent"
+          >
+            <Image
+              width={0}
+              height={0}
+              sizes="100vw"
+              loading="lazy"
+              className="max-w-3 max-h-3"
+              src={close_dialog}
+              alt="close"
+            />
+          </button>
+        </div>
+        <div className="px-9 pb-10 space-y-6">
+          <div>
+            <Image
+              width={56}
+              height={56}
+              src={green_check_circle}
+              alt="success"
+              className="mb-6"
+            />
+            <h2 className="text-2xl font-medium text-dark_green mb-3">
+              Anfrage erfolgreich versendet
+            </h2>
+            <p className="text-dark_green/70 text-sm leading-relaxed">
+              Die einzelnen PDF-Dokumente werden Ihnen innerhalb der nächsten 24 Stunden zur Verfügung gestellt.
+            </p>
+          </div>
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="px-8 py-3 cursor-pointer rounded-md bg-green text-dark_green font-medium border-none shadow-xs transition-all duration-300 hover:opacity-80"
+          >
+            Weiter
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# feat: 24-Hour PDF Access Restriction for Heating Bills

## What Was Changed

### New Component
- **`src/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal.tsx`**
  A new client-side modal overlay that notifies non-super-admin users that their heating bill PDFs are pending. Displays automatically when the 24-hour window is active. The "Weiter" button redirects to `/dashboard`; the X button dismisses the modal in place.

### API Layer (`src/api/index.ts`)
- **`getCurrentUserDocuments()`** — Now fetches `created_at` from `heating_bill_documents` alongside existing fields. For non-super-admin users, heating bill documents whose parent record was created within the last 24 hours are excluded from the result set. Super admins are unaffected.
- **`getDocumentsByObjektIds()`** — Added an optional third parameter `viewerIsSuperAdmin: boolean` (defaults to `false`). Applies the same 24-hour filter on heating bill documents when the viewer is not a super admin.

### Admin Dokumente Page (`src/app/(admin)/admin/[user_id]/dokumente/page.tsx`)
- Added a role check for the **current viewer** (the admin browsing the page, not the user being managed). The resolved `viewerIsSuperAdmin` flag is passed to `getDocumentsByObjektIds()` so that the 24-hour filter is applied correctly based on who is viewing, not whose documents are shown.

### Results Pages — All 4 Variants
Each results page now:
1. Resolves the current viewer's role (`isSuperAdmin`)
2. Queries `heating_bill_documents.created_at` for the active `doc_id`
3. Computes `isPdfPending = !isSuperAdmin && created_at > now - 24h`
4. Renders `<HeatingBillPDFPendingModal isOpen={isPdfPending} />` as an overlay
5. Passes an empty `tenantDocuments` array to child components when `isPdfPending` is true, preventing any PDF links from rendering

Pages modified:
- `src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx`
- `src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx`
- `src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx`
- `src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx`

---

## Why It Was Changed

After a heating bill is generated, PDFs were immediately accessible to all authenticated users. This was not the intended behaviour. The requirement is:

- **Super admins** can view and download generated PDFs immediately after generation.
- **Admins and regular users** must wait 24 hours before PDFs become visible in the results pages and the Dokumente route.

The 24-hour window is intentionally measured against `heating_bill_documents.created_at` — the parent billing record — rather than against `documents.created_at` (the individual PDF file). This ensures that if a super admin manually overwrites a PDF via upload, the clock does **not** reset; the original generation timestamp governs access.

---

## Impact on CI, Deployments, or Infrastructure

- **No database migrations required.** `heating_bill_documents.created_at` already exists in the schema with a default of `now()`.
- **No new environment variables or external service changes.**
- **No breaking changes to existing API contracts.** The `getDocumentsByObjektIds` signature change is backwards-compatible (new param is optional with a safe default).
- **No impact on Supabase RLS policies.** The 24-hour filter is applied at the application layer, not via row-level security.
- **Performance:** Two additional lightweight DB lookups are added per results page load (role check + `heating_bill_documents` timestamp fetch). Both are single-row selects with indexed primary/foreign key lookups — negligible overhead.

---

## Required Follow-Up Actions

- [ ] **Test all four user role scenarios** end-to-end in staging: `super_admin`, `agency_admin`, `admin`, and `user`.
- [ ] **Verify the 24-hour window resets correctly** — confirm that uploading a replacement PDF via the super-admin upload tool does NOT extend the restriction window for other users.
- [ ] **Consider protecting the preview sub-routes** (`/results/[local_id]/preview` and `/results/preview`) against direct URL access during the 24-hour window. Currently these are only reachable by navigating through the results page (which passes empty docs), but a user with a direct URL could still access them. This was descoped from the current PR to keep the change focused.
- [ ] **QA the Dokumente route** for both the user-facing (`/dokumente`) and admin-facing (`/admin/[user_id]/dokumente`) pages to confirm heating bill entries are hidden during the 24-hour period and reappear correctly afterwards.
