### PR TITLE
feat: Implement cost allocation fallback to living space (sqm) for he…

### DIFF
--- a/src/app/api/heating-bill/_lib/coldwater.ts
+++ b/src/app/api/heating-bill/_lib/coldwater.ts
@@ -55,6 +55,8 @@ export type ColdWaterRateItem = {
   rate: number;
   rateFormatted: string;
   rateUnit: string;
+  /** "sqm" when no cold water readings — unit cost uses localSqm × rate; "consumption" otherwise */
+  allocationMode: "sqm" | "consumption";
 };
 
 export type ColdWaterResult = {
@@ -63,6 +65,8 @@ export type ColdWaterResult = {
   rateItems: ColdWaterRateItem[];
   unitTotalCost: number;
   unitTotalCostFormatted: string;
+  /** True when no cold water meter readings are available; costs are allocated by sqm in unit breakdown */
+  noReadings: boolean;
 };
 
 /**
@@ -77,6 +81,7 @@ export function computeColdWaterRates(
 ): ColdWaterResult {
   const unitCountSafe = Math.max(1, unitCount);
   const totalM3Safe = Math.max(0.001, totalColdWaterM3);
+  const noReadings = totalColdWaterM3 === 0;
 
   // Group by subtype (label)
   const bySubtype = new Map<
@@ -100,28 +105,44 @@ export function computeColdWaterRates(
 
   for (const [, item] of bySubtype) {
     totalCost += item.amount;
-    const volume =
-      item.unit === "m3"
-        ? totalM3Safe
-        : unitCountSafe;
-    const rate = volume > 0 ? round6(item.amount / volume) : 0;
-    const volumeFormatted =
-      item.unit === "m3"
-        ? formatGermanNumber(totalM3Safe, 2)
-        : formatGermanNumber(unitCountSafe, 0);
-    const unit = item.unit === "m3" ? "m³" : "Nutzeinh.";
-    const rateUnit = item.unit === "m3" ? "€/m³" : "€/Nutzeinh.";
-    rateItems.push({
-      label: item.label,
-      totalCost: item.amount,
-      totalCostFormatted: formatEuro(item.amount),
-      totalVolume: volume,
-      totalVolumeFormatted: volumeFormatted,
-      unit,
-      rate,
-      rateFormatted: formatGermanNumber(rate, item.decimals),
-      rateUnit,
-    });
+
+    if (noReadings && item.unit === "m3") {
+      // No readings: allocate by sqm (€/m² rate)
+      const rate = totalLivingSpaceM2 > 0 ? round6(item.amount / totalLivingSpaceM2) : 0;
+      rateItems.push({
+        label: item.label,
+        totalCost: item.amount,
+        totalCostFormatted: formatEuro(item.amount),
+        totalVolume: totalLivingSpaceM2,
+        totalVolumeFormatted: formatGermanNumber(totalLivingSpaceM2, 2),
+        unit: "m²",
+        rate,
+        rateFormatted: formatGermanNumber(rate, item.decimals),
+        rateUnit: "€/m²",
+        allocationMode: "sqm",
+      });
+    } else {
+      const volume = item.unit === "m3" ? totalM3Safe : unitCountSafe;
+      const rate = volume > 0 ? round6(item.amount / volume) : 0;
+      const volumeFormatted =
+        item.unit === "m3"
+          ? formatGermanNumber(totalM3Safe, 2)
+          : formatGermanNumber(unitCountSafe, 0);
+      const unit = item.unit === "m3" ? "m³" : "Nutzeinh.";
+      const rateUnit = item.unit === "m3" ? "€/m³" : "€/Nutzeinh.";
+      rateItems.push({
+        label: item.label,
+        totalCost: item.amount,
+        totalCostFormatted: formatEuro(item.amount),
+        totalVolume: volume,
+        totalVolumeFormatted: volumeFormatted,
+        unit,
+        rate,
+        rateFormatted: formatGermanNumber(rate, item.decimals),
+        rateUnit,
+        allocationMode: "consumption",
+      });
+    }
   }
 
   // Fallback if no cold water invoices: one placeholder item
@@ -131,16 +152,19 @@ export function computeColdWaterRates(
       label: "Kaltwasser",
       totalCost: 0,
       totalCostFormatted: formatEuro(0),
-      totalVolume: totalM3Safe,
-      totalVolumeFormatted: formatGermanNumber(totalM3Safe, 2),
-      unit: "m³",
+      totalVolume: noReadings ? totalLivingSpaceM2 : totalM3Safe,
+      totalVolumeFormatted: noReadings
+        ? formatGermanNumber(totalLivingSpaceM2, 2)
+        : formatGermanNumber(totalM3Safe, 2),
+      unit: noReadings ? "m²" : "m³",
       rate: 0,
       rateFormatted: "0",
-      rateUnit: "€/m³",
+      rateUnit: noReadings ? "€/m²" : "€/m³",
+      allocationMode: noReadings ? "sqm" : "consumption",
     });
   }
 
-  // Unit share: proportional by living space for m³ items, equal split for per-unit items
+  // Unit share: proportional by living space for m³/m² items, equal split for per-unit items
   let unitTotalCost = 0;
   const localSpace = localLivingSpaceM2 ?? 0;
   const spaceShare =
@@ -149,7 +173,7 @@ export function computeColdWaterRates(
       : 1 / unitCountSafe;
 
   for (const item of rateItems) {
-    if (item.unit === "m³") {
+    if (item.unit === "m³" || item.unit === "m²") {
       unitTotalCost += item.totalCost * spaceShare;
     } else {
       unitTotalCost += item.totalCost / unitCountSafe;
@@ -163,5 +187,6 @@ export function computeColdWaterRates(
     rateItems,
     unitTotalCost,
     unitTotalCostFormatted: formatEuro(unitTotalCost),
+    noReadings,
   };
 }

--- a/src/app/api/heating-bill/_lib/compute.ts
+++ b/src/app/api/heating-bill/_lib/compute.ts
@@ -362,6 +362,7 @@ export function computeHeatingBill(
   model.unitBreakdown = computeUnitBreakdown({
     localId: targetLocalId ?? "",
     livingSpaceM2: localLivingSpaceM2 || 0,
+    totalLivingSpaceM2: totalLivingSpace || 0,
     heating,
     warmWater,
     coldWaterRateItems: coldWater.rateItems,

--- a/src/app/api/heating-bill/_lib/rates.ts
+++ b/src/app/api/heating-bill/_lib/rates.ts
@@ -36,6 +36,8 @@ export type HeatingRates = {
   consumptionCostRatePerUnit: number;
   consumptionCostRatePerUnitFormatted: string;
   consumptionUnit: string;
+  /** True when no heat meter readings are available; costs are allocated by sqm in unit breakdown */
+  noReadings: boolean;
 };
 
 /**
@@ -103,5 +105,6 @@ export function computeHeatingRates(
       6
     ),
     consumptionUnit,
+    noReadings: consumptionValue === 0,
   };
 }

--- a/src/app/api/heating-bill/_lib/unit-breakdown.ts
+++ b/src/app/api/heating-bill/_lib/unit-breakdown.ts
@@ -16,6 +16,8 @@ export type UnitBreakdownInput = {
   /** Target local for this breakdown */
   localId: string;
   livingSpaceM2: number;
+  /** Building total living space m² — required for sqm-based fallback allocation */
+  totalLivingSpaceM2: number;
   /** Building-level heating rates */
   heating: HeatingRates;
   /** Building-level warm water result */
@@ -55,6 +57,7 @@ export type UnitBreakdownInput = {
 export function computeUnitBreakdown(input: UnitBreakdownInput): HeatingBillPdfModel["unitBreakdown"] {
   const {
     livingSpaceM2,
+    totalLivingSpaceM2,
     heating,
     warmWater,
     coldWaterRateItems,
@@ -74,19 +77,28 @@ export function computeUnitBreakdown(input: UnitBreakdownInput): HeatingBillPdfM
   const tf = input.timeFraction ?? 1;
   const cUnit = input.consumptionUnit ?? "MWh";
   const isHca = cUnit === "Nutzeinh.";
+  const sqmShare = totalLivingSpaceM2 > 0 ? livingSpaceM2 / totalLivingSpaceM2 : 0;
 
-  // Base costs are area-based — scale by time fraction for multi-tenant proration
-  const heatingBaseCost = round2(livingSpaceM2 * heating.baseCostRatePerM2 * tf);
-  // Consumption costs use tenant-scoped meter readings — no time scaling needed
-  const heatingConsumptionValue = heatingDevices.reduce((s, d) => s + d.consumption, 0);
-  const heatingConsumptionCost = round2(heatingConsumptionValue * (heating.consumptionCostAmount / Math.max(0.001, heating.consumptionValue)));
+  // Heat: sqm fallback when no readings — allocate 100% of heating cost by sqm
+  const heatingBaseCost = heating.noReadings
+    ? round2(heating.totalCost * sqmShare * tf)
+    : round2(livingSpaceM2 * heating.baseCostRatePerM2 * tf);
+  const heatingConsumptionValue = heating.noReadings
+    ? 0
+    : heatingDevices.reduce((s, d) => s + d.consumption, 0);
+  const heatingConsumptionCost = heating.noReadings
+    ? 0
+    : round2(heatingConsumptionValue * (heating.consumptionCostAmount / Math.max(0.001, heating.consumptionValue)));
 
-  const warmWaterBaseCost = round2(livingSpaceM2 * warmWater.baseCostRatePerM2 * tf);
+  // Warm water: sqm fallback when no readings — allocate 100% of warm water cost by sqm
+  const warmWaterBaseCost = warmWater.noReadings
+    ? round2(warmWater.totalCost * sqmShare * tf)
+    : round2(livingSpaceM2 * warmWater.baseCostRatePerM2 * tf);
   // HCA warm water rule: warm water consumption cost is 0 for HCA apartments.
   // Hot water cost allocation only applies when consumption is in kWh (Wärmezähler).
   // The warm water base cost (area-based Grundkosten) still applies.
-  const warmWaterConsumptionM3 = isHca ? 0 : warmWaterDevices.reduce((s, d) => s + d.consumption, 0);
-  const warmWaterConsumptionCost = isHca ? 0 : round2(
+  const warmWaterConsumptionM3 = (isHca || warmWater.noReadings) ? 0 : warmWaterDevices.reduce((s, d) => s + d.consumption, 0);
+  const warmWaterConsumptionCost = (isHca || warmWater.noReadings) ? 0 : round2(
     warmWaterConsumptionM3 * (warmWater.consumptionCostAmount / Math.max(0.001, warmWater.consumptionCostVolume))
   );
 
@@ -96,6 +108,21 @@ export function computeUnitBreakdown(input: UnitBreakdownInput): HeatingBillPdfM
 
   const unitColdWaterM3 = coldWaterDevices.reduce((s, d) => s + d.consumption, 0);
   const coldWaterItems = coldWaterRateItems.map((item) => {
+    // Cold water sqm fallback: use living space m² when no readings
+    if (item.allocationMode === "sqm") {
+      const cost = round2(livingSpaceM2 * item.rate * tf);
+      return {
+        label: item.label,
+        volume: livingSpaceM2,
+        volumeFormatted: formatGermanNumber(livingSpaceM2, 2),
+        unit: item.unit,
+        rate: item.rate,
+        rateFormatted: item.rateFormatted,
+        rateUnit: item.rateUnit,
+        cost,
+        costFormatted: formatEuro(cost),
+      };
+    }
     const volume =
       item.unit === "Nutzeinh."
         ? 1

--- a/src/app/api/heating-bill/_lib/warmwater.ts
+++ b/src/app/api/heating-bill/_lib/warmwater.ts
@@ -56,6 +56,8 @@ export type WarmWaterResult = {
   consumptionCostVolumeFormatted: string;
   consumptionCostRatePerM3: number;
   consumptionCostRatePerM3Formatted: string;
+  /** True when no warm water meter readings are available; costs are allocated by sqm in unit breakdown */
+  noReadings: boolean;
 };
 
 /**
@@ -153,5 +155,6 @@ export function computeWarmWaterCosts(
       consumptionCostRatePerM3,
       6
     ),
+    noReadings: volumeM3 === 0,
   };
 }


### PR DESCRIPTION
## Summary

Implements sqm-based (square meter proportional) cost allocation as a fallback for heat, warm water, and cold water categories when no consumption meter readings are available for the billing period.

---

## What Was Changed

### Problem

When a building has no meters installed for a category (e.g. no cold water meters, no warm water meters), the existing calculation produced incorrect results:

- **Heat (no readings):** Only the 30% area-based portion was allocated to units. The 70% consumption-based portion was silently lost — never charged to any tenant.
- **Warm water (no readings):** Same issue — only 30% of device rental was allocated; 70% was unallocated.
- **Cold water (no readings):** Unit cost was calculated as `0 m³ × rate = €0`, meaning the entire cold water invoice went unallocated.

### Solution

For any category where no consumption readings exist, 100% of that category's invoiced cost is now divided proportionally by living space (sqm):

```
unitCost = totalCategoryCost × (unitSqm / totalBuildingSqm)
```

**Example:** Cold water bill €1,000, building 2,000 m², unit 200 m²
→ Unit pays: 200 / 2,000 × €1,000 = **€100**

### Files Modified

| File | Change |
|------|--------|
| `src/app/api/heating-bill/_lib/rates.ts` | Added `noReadings: boolean` to `HeatingRates` — set to `true` when `consumptionValue === 0` |
| `src/app/api/heating-bill/_lib/warmwater.ts` | Added `noReadings: boolean` to `WarmWaterResult` — set to `true` when `volumeM3 === 0` |
| `src/app/api/heating-bill/_lib/coldwater.ts` | Added `allocationMode: "sqm" \| "consumption"` to `ColdWaterRateItem`; when `totalColdWaterM3 === 0`, rate items use `€/m²` instead of `€/m³` |
| `src/app/api/heating-bill/_lib/unit-breakdown.ts` | Added `totalLivingSpaceM2` to input; applies sqm fallback for all three categories when `noReadings` is set |
| `src/app/api/heating-bill/_lib/compute.ts` | Passes `totalLivingSpace` to `computeUnitBreakdown` |

### Allocation Logic Per Category

| Category | Trigger | New Fallback |
|----------|---------|--------------|
| Heat | `heatingConsumptionValue === 0` | `heating.totalCost × (unitSqm / totalSqm) × timeFraction` |
| Warm water | `warmWaterVolumeM3 === 0` | `warmWater.totalCost × (unitSqm / totalSqm) × timeFraction` |
| Cold water | `totalColdWaterM3 === 0` | `unitSqm × (categoryTotal / totalSqm) × timeFraction` |

Multi-tenant time proration (`timeFraction`) is preserved in all fallback paths.

---

## Why It Was Changed

German heating cost law (HeizKV) requires that all allocated costs must be fully distributed to tenants. Silent unallocated amounts violate this requirement and produce incorrect billing totals. This change ensures that buildings without specific meter types can still generate legally compliant bills by falling back to the standard sqm-proportional allocation method.

---

## Impact on CI / Deployments / Infrastructure

- **No schema changes** — purely computational logic in existing lib functions.
- **No new dependencies.**
- **Build verified** — `pnpm build` passes with no TypeScript errors.
- **Existing behaviour unchanged** when readings are present — all `noReadings` flags default to `false` when consumption data exists, preserving the current 30/70 split logic exactly.
- **PDF output** will reflect the new `€/m²` rate unit in cold water line items when no readings are present, which is the correct display for sqm-based allocation.

---

## Required Follow-up Actions

- [ ] **QA:** Test PDF generation for a building with no cold water meters — verify unit cold water cost equals `totalInvoice × (unitSqm / buildingSqm)`.
- [ ] **QA:** Test PDF generation for a building with no warm water meters — verify warm water cost equals `wwDeviceRental × (unitSqm / buildingSqm)`.
- [ ] **QA:** Test PDF generation for a building with no heat meters — verify heating cost equals `heatingTotal × (unitSqm / buildingSqm)` with no consumption line.
- [ ] **Regression:** Verify existing buildings with all meter types present produce identical PDF output to before this change.
