### PR TITLE
fix: tenant login redirect and shared dashboard empty data display

### DIFF
--- a/src/app/(base)/layout.tsx
+++ b/src/app/(base)/layout.tsx
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer/Footer";
 import QueryProvider from "../QueryProvider";
 import { Toaster } from "@/components/Basic/ui/Sonner";
 import { Suspense, lazy } from "react";
+import TenantLoginAutoOpen from "@/components/Basic/TenantLoginAutoOpen";
 
 // Lazy-load the dialogs
 const LazyLoginDialog = lazy(() => import("@/components/Basic/Dialog/LoginDialog"));
@@ -43,6 +44,9 @@ export default function BaseLayout({
       </Suspense>
       <Suspense fallback={null}>
         <LazyTenantForgotPasswordDialog />
+      </Suspense>
+      <Suspense fallback={null}>
+        <TenantLoginAutoOpen />
       </Suspense>
       <Toaster />
     </QueryProvider>

--- a/src/app/mieter/dashboard/page.tsx
+++ b/src/app/mieter/dashboard/page.tsx
@@ -88,7 +88,8 @@ function DashboardContent() {
         const sessionData = await sessionRes.json();
         
         if (!sessionRes.ok || !sessionData.authenticated) {
-          router.push('/mieter/login');
+          // Redirect to main site with param to auto-open tenant login dialog
+          router.push('/?tenant-login=true');
           return;
         }
         

--- a/src/app/shared/dashboard/page.tsx
+++ b/src/app/shared/dashboard/page.tsx
@@ -97,19 +97,9 @@ export default async function SharedDashboardPage({ searchParams }: SharedDashbo
     filters.endDate
   );
   
-  if (!parsedData?.data || parsedData.data.length === 0) {
-    return (
-      <div className="py-6 px-9 flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-red-600 mb-4">Data Unavailable</h1>
-          <p className="text-gray-600">Unable to load dashboard data at this time.</p>
-          {parsedData.errors.length > 0 && (
-            <p className="text-sm text-gray-400 mt-2">Error: {parsedData.errors[0]}</p>
-          )}
-        </div>
-      </div>
-    );
-  }
+  // Note: We no longer show "Data Unavailable" error when there's no data.
+  // Instead, let the dashboard render with empty charts showing "Keine Daten" messages.
+  // This provides better UX for tenants viewing buildings with no readings yet.
 
   // Filter out header rows (meter ID filtering now done at database level)
   let filteredData = parsedData?.data?.filter((item: any) => item["Device Type"] !== "Device Type");

--- a/src/components/Basic/TenantLoginAutoOpen.tsx
+++ b/src/components/Basic/TenantLoginAutoOpen.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useDialogStore } from "@/store/useDIalogStore";
+
+/**
+ * Component that detects ?tenant-login=true in URL and auto-opens the TenantLoginDialog.
+ * Used when redirecting from /mieter/dashboard for unauthenticated tenants.
+ */
+export default function TenantLoginAutoOpen() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { openDialog } = useDialogStore();
+
+  useEffect(() => {
+    const shouldOpenLogin = searchParams.get("tenant-login") === "true";
+    
+    if (shouldOpenLogin) {
+      // Open the tenant login dialog
+      openDialog("tenantLogin");
+      
+      // Remove the query param from URL (clean URL)
+      const url = new URL(window.location.href);
+      url.searchParams.delete("tenant-login");
+      router.replace(url.pathname + url.search, { scroll: false });
+    }
+  }, [searchParams, openDialog, router]);
+
+  return null; // This component doesn't render anything
+}


### PR DESCRIPTION
## Summary
- **Tenant login redirect fix**: Unauthenticated tenants accessing `/mieter/dashboard` are now redirected to `/?tenant-login=true` (main site) which auto-opens the tenant login dialog, instead of redirecting to a non-existent `/mieter/login` page
- **Shared dashboard empty data fix**: Removed the "Data Unavailable" error page when buildings have meters but no consumption data yet - dashboard now renders with empty charts showing "Keine Daten" messages for better UX

## Changes
- `src/app/mieter/dashboard/page.tsx` - Changed redirect from `/mieter/login` to `/?tenant-login=true`
- `src/components/Basic/TenantLoginAutoOpen.tsx` - New component that detects `?tenant-login=true` param and auto-opens the `TenantLoginDialog`
- `src/app/(base)/layout.tsx` - Added `TenantLoginAutoOpen` component
- `src/app/shared/dashboard/page.tsx` - Removed the conditional "Data Unavailable" error page for empty data

## Note for Nic
Please add the following environment variables to Vercel:
- `MAKE_WEBHOOK_TENANT_REMINDER` 
- `CRON_SECRET` (for Phase 3 cron job auth)

Also configure Vercel Cron to call `/api/cron/tenant-reminders` daily after merge.