### PR TITLE
feat: Introduce API for all heating bill documents per object and enh…

### DIFF
--- a/src/apiClient/index.ts
+++ b/src/apiClient/index.ts
@@ -225,11 +225,11 @@ export function useUserDocumentsByType(documentType: string) {
 export const getDocumentDownloadUrl = async (documentPath: string): Promise<string> => {
   const data = await supabase.storage
     .from("documents")
-    .createSignedUrl(documentPath, 60 * 60, {download: true});
+    .createSignedUrl(documentPath, 60 * 60, { download: true });
 
-    if (data.error) {
-      throw new Error(`Failed to fetch document download URL: ${data.error.message}`);
-    }
+  if (data.error) {
+    throw new Error(`Failed to fetch document download URL: ${data.error.message}`);
+  }
 
   return data.data.signedUrl;
 };
@@ -239,9 +239,9 @@ export const getDocumentViewUrl = async (documentPath: string): Promise<string> 
     .from("documents")
     .createSignedUrl(documentPath, 60 * 60);
 
-    if (data.error) {
-      throw new Error(`Failed to fetch document view URL: ${data.error.message}`);
-    }
+  if (data.error) {
+    throw new Error(`Failed to fetch document view URL: ${data.error.message}`);
+  }
 
   return data.data.signedUrl;
 };
@@ -552,6 +552,28 @@ export function useHeatingBillBuildingDocumentsByObjektID(objectID?: string) {
   });
 }
 
+async function getAllHeatingBillDocumentsByObjektID(objectID?: string): Promise<HeatingBillDocumentType[]> {
+
+  const { data, error } = await supabase
+    .from("heating_bill_documents")
+    .select("*")
+    .eq("objekt_id", objectID);
+
+  if (error) {
+    throw new Error(`Failed to fetch objects: ${error.message}`);
+  }
+
+  return data;
+}
+
+export function useAllHeatingBillDocumentsByObjektID(objectID?: string) {
+  return useQuery({
+    queryKey: ["all_heating_bill_documents", objectID],
+    queryFn: () => getAllHeatingBillDocumentsByObjektID(objectID),
+    refetchOnWindowFocus: false,
+    enabled: !!objectID,
+  });
+}
 
 export async function uploadObjektImage(file: File, objektId: string): Promise<string> {
   const filePath = `images/${objektId}/${file.name}`;

--- a/src/components/Admin/ObjekteItem/Admin/AdminHeatObjekteItemDocWithHistory.tsx
+++ b/src/components/Admin/ObjekteItem/Admin/AdminHeatObjekteItemDocWithHistory.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import {
-  useHeatingBillBuildingDocumentsByObjektID,
+  useAllHeatingBillDocumentsByObjektID,
   useLocalsByObjektID,
 } from "@/apiClient";
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import { close_dialog, operating_cost_documents_pending } from "@/static/icons";
+import { close_dialog, green_check_circle, operating_cost_documents_pending } from "@/static/icons";
 import { useDialogStore } from "@/store/useDIalogStore";
 import { type ObjektType } from "@/types";
 import { countLocals, slideDown, slideUp } from "@/utils";
@@ -44,7 +44,7 @@ export default function AdminHeatObjekteItemDocWithHistory({
 
   const { data: relatedLocals } = useLocalsByObjektID(item.id);
   const { data: relatedOpenedDocuments } =
-    useHeatingBillBuildingDocumentsByObjektID(item.id);
+    useAllHeatingBillDocumentsByObjektID(item.id);
 
   const { commertialLocals, otherLocals } = countLocals(
     relatedLocals ? relatedLocals : []
@@ -74,46 +74,55 @@ export default function AdminHeatObjekteItemDocWithHistory({
         ref={contentRef}
         className="[.active_&]:pt-6 [.active_&]:pb-2 space-y-6 px-24 [.active_&]:h-auto h-0"
       >
-        {relatedOpenedDocuments?.map((doc) => (
-          <div className="flex items-center justify-between" key={doc.id}>
-            <Link
-              className="flex items-center justify-start gap-8"
-              href={`${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`}
-            >
-              <Image
-                width={0}
-                height={0}
-                sizes="100vw"
-                loading="lazy"
-                className="max-w-6 max-h-6 max-xl:max-w-4 max-xl:max-h-4"
-                src={operating_cost_documents_pending}
-                alt="operating_cost_documents_pending"
-              />
-              {item.street} {item.zip}:{" "}
-              {doc.start_date
-                ? format(new Date(doc.start_date), "dd.MM.yyyy", { locale: de })
-                : "?"}
-              {" - "}
-              {doc.end_date
-                ? format(new Date(doc.end_date), "dd.MM.yyyy", { locale: de })
-                : "?"}
-            </Link>
-            <button
-              onClick={() => openDeleteDialog(doc.id ? doc.id : "")}
-              className="cursor-pointer"
-            >
-              <Image
-                width={0}
-                height={0}
-                sizes="100vw"
-                loading="lazy"
-                className="max-w-2.5 max-h-2.5"
-                src={close_dialog}
-                alt="close_dialog"
-              />
-            </button>
-          </div>
-        ))}
+        {relatedOpenedDocuments?.map((doc) => {
+          const isSubmitted = doc.submited;
+          const href = isSubmitted
+            ? `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${item.id}/${doc.id}/results`
+            : doc.local_id
+              ? `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/weitermachen/${doc.id}/abrechnungszeitraum`
+              : `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`;
+
+          return (
+            <div className="flex items-center justify-between" key={doc.id}>
+              <Link
+                className="flex items-center justify-start gap-8"
+                href={href}
+              >
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-6 max-h-6 max-xl:max-w-4 max-xl:max-h-4"
+                  src={isSubmitted ? green_check_circle : operating_cost_documents_pending}
+                  alt={isSubmitted ? "submitted_document" : "draft_document"}
+                />
+                {item.street} {item.zip}:{" "}
+                {doc.start_date
+                  ? format(new Date(doc.start_date), "dd.MM.yyyy", { locale: de })
+                  : "?"}
+                {" - "}
+                {doc.end_date
+                  ? format(new Date(doc.end_date), "dd.MM.yyyy", { locale: de })
+                  : "?"}
+              </Link>
+              <button
+                onClick={() => openDeleteDialog(doc.id ? doc.id : "")}
+                className="cursor-pointer"
+              >
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-2.5 max-h-2.5"
+                  src={close_dialog}
+                  alt="close_dialog"
+                />
+              </button>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Admin/ObjekteItem/ObjekteItemDocWithHistory.tsx
+++ b/src/components/Admin/ObjekteItem/ObjekteItemDocWithHistory.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import {
-  useHeatingBillBuildingDocumentsByObjektID,
+  useAllHeatingBillDocumentsByObjektID,
   useLocalsByObjektID,
 } from "@/apiClient";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import { close_dialog, operating_cost_documents_pending } from "@/static/icons";
+import { close_dialog, green_check_circle, operating_cost_documents_pending } from "@/static/icons";
 import { useDialogStore } from "@/store/useDIalogStore";
 import { type ObjektType } from "@/types";
 import { countLocals, slideDown, slideUp } from "@/utils";
@@ -42,7 +42,7 @@ export default function ObjekteItemDocWithHistory({
 
   const { data: relatedLocals } = useLocalsByObjektID(item.id);
   const { data: relatedOpenedDocuments } =
-    useHeatingBillBuildingDocumentsByObjektID(item.id);
+    useAllHeatingBillDocumentsByObjektID(item.id);
 
   const { commertialLocals, otherLocals } = countLocals(
     relatedLocals ? relatedLocals : []
@@ -72,46 +72,55 @@ export default function ObjekteItemDocWithHistory({
         ref={contentRef}
         className="[.active_&]:pt-6 [.active_&]:pb-2 space-y-6 px-24 [.active_&]:h-auto h-0"
       >
-        {relatedOpenedDocuments?.map((doc) => (
-          <div className="flex items-center justify-between" key={doc.id}>
-            <Link
-              className="flex items-center justify-start gap-8"
-              href={`${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`}
-            >
-              <Image
-                width={0}
-                height={0}
-                sizes="100vw"
-                loading="lazy"
-                className="max-w-6 max-h-6 max-xl:max-w-4 max-xl:max-h-4"
-                src={operating_cost_documents_pending}
-                alt="operating_cost_documents_pending"
-              />
-              {item.street} {item.zip}:{" "}
-              {doc.start_date
-                ? format(new Date(doc.start_date), "dd.MM.yyyy", { locale: de })
-                : "?"}
-              {" - "}
-              {doc.end_date
-                ? format(new Date(doc.end_date), "dd.MM.yyyy", { locale: de })
-                : "?"}
-            </Link>
-            <button
-              onClick={() => openDeleteDialog(doc.id ? doc.id : "")}
-              className="cursor-pointer"
-            >
-              <Image
-                width={0}
-                height={0}
-                sizes="100vw"
-                loading="lazy"
-                className="max-w-2.5 max-h-2.5"
-                src={close_dialog}
-                alt="close_dialog"
-              />
-            </button>
-          </div>
-        ))}
+        {relatedOpenedDocuments?.map((doc) => {
+          const isSubmitted = doc.submited;
+          const href = isSubmitted
+            ? `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${item.id}/${doc.id}/results`
+            : doc.local_id
+              ? `${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/weitermachen/${doc.id}/abrechnungszeitraum`
+              : `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`;
+
+          return (
+            <div className="flex items-center justify-between" key={doc.id}>
+              <Link
+                className="flex items-center justify-start gap-8"
+                href={href}
+              >
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-6 max-h-6 max-xl:max-w-4 max-xl:max-h-4"
+                  src={isSubmitted ? green_check_circle : operating_cost_documents_pending}
+                  alt={isSubmitted ? "submitted_document" : "draft_document"}
+                />
+                {item.street} {item.zip}:{" "}
+                {doc.start_date
+                  ? format(new Date(doc.start_date), "dd.MM.yyyy", { locale: de })
+                  : "?"}
+                {" - "}
+                {doc.end_date
+                  ? format(new Date(doc.end_date), "dd.MM.yyyy", { locale: de })
+                  : "?"}
+              </Link>
+              <button
+                onClick={() => openDeleteDialog(doc.id ? doc.id : "")}
+                className="cursor-pointer"
+              >
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-2.5 max-h-2.5"
+                  src={close_dialog}
+                  alt="close_dialog"
+                />
+              </button>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Admin/ObjekteLocalsAccordion/Admin/AdminHeatObjekteItemDocAccordion.tsx
+++ b/src/components/Admin/ObjekteLocalsAccordion/Admin/AdminHeatObjekteItemDocAccordion.tsx
@@ -9,17 +9,27 @@ export default function AdminHeatObjekteItemDocAccordion({
 }: {
   objekts?: ObjektType[];
 }) {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [closedIds, setClosedIds] = useState<Set<string>>(new Set());
 
   const handleClick = (index: number) => {
-    setOpenIndex((prev) => (prev === index ? null : index));
+    const objekt = objekts?.[index];
+    if (!objekt || !objekt.id) return;
+    setClosedIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(objekt.id as string)) {
+        newSet.delete(objekt.id as string);
+      } else {
+        newSet.add(objekt.id as string);
+      }
+      return newSet;
+    });
   };
 
   return (
     <div className="overflow-y-auto space-y-4">
       {objekts?.map((objekt, index) => (
         <AdminHeatObjekteItemDocWithHistory
-          isOpen={openIndex === index}
+          isOpen={!closedIds.has(objekt.id as string)}
           onClick={handleClick}
           key={objekt.id}
           index={index}

--- a/src/components/Admin/ObjekteLocalsAccordion/Admin/AdminObjekteItemDocAccordion.tsx
+++ b/src/components/Admin/ObjekteLocalsAccordion/Admin/AdminObjekteItemDocAccordion.tsx
@@ -9,12 +9,22 @@ export default function AdminObjekteItemDocAccordion({
 }: {
   objekts?: ObjektType[];
 }) {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [closedIds, setClosedIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
   const handleClick = (index: number) => {
-    setOpenIndex((prev) => (prev === index ? null : index));
+    const objekt = filteredAndSortedObjekts[index];
+    if (!objekt || !objekt.id) return;
+    setClosedIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(objekt.id as string)) {
+        newSet.delete(objekt.id as string);
+      } else {
+        newSet.add(objekt.id as string);
+      }
+      return newSet;
+    });
   };
 
   const filteredAndSortedObjekts = useMemo(() => {
@@ -61,7 +71,7 @@ export default function AdminObjekteItemDocAccordion({
           </p>
           {filteredAndSortedObjekts.map((objekt, index) => (
             <AdminObjekteItemDocWithHistory
-              isOpen={openIndex === index}
+              isOpen={!closedIds.has(objekt.id as string)}
               onClick={handleClick}
               key={objekt.id}
               index={index}

--- a/src/components/Admin/ObjekteLocalsAccordion/ObjekteItemDocAccordion.tsx
+++ b/src/components/Admin/ObjekteLocalsAccordion/ObjekteItemDocAccordion.tsx
@@ -9,18 +9,28 @@ export default function ObjekteItemDocAccordion({
 }: {
   objekts?: ObjektType[];
 }) {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [closedIds, setClosedIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState("");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
   const handleClick = (index: number) => {
-    setOpenIndex((prev) => (prev === index ? null : index));
+    const objekt = filteredAndSortedObjekts[index];
+    if (!objekt || !objekt.id) return;
+    setClosedIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(objekt.id as string)) {
+        newSet.delete(objekt.id as string);
+      } else {
+        newSet.add(objekt.id as string);
+      }
+      return newSet;
+    });
   };
 
   // Filter and sort objekts
   const filteredAndSortedObjekts = useMemo(() => {
     if (!objekts) return [];
-    
+
     let result = [...objekts];
 
     // Filter by search query
@@ -92,7 +102,7 @@ export default function ObjekteItemDocAccordion({
         ) : (
           filteredAndSortedObjekts.map((objekt, index) => (
             <ObjekteItemDocWithHistory
-              isOpen={openIndex === index}
+              isOpen={!closedIds.has(objekt.id as string)}
               onClick={handleClick}
               key={objekt.id}
               index={index}

--- a/src/components/Admin/ObjekteLocalsAccordion/OperatingObjekteItemDocAccordion.tsx
+++ b/src/components/Admin/ObjekteLocalsAccordion/OperatingObjekteItemDocAccordion.tsx
@@ -9,12 +9,22 @@ export default function OperatingObjekteItemDocAccordion({
 }: {
   objekts?: ObjektType[];
 }) {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [closedIds, setClosedIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
   const handleClick = (index: number) => {
-    setOpenIndex((prev) => (prev === index ? null : index));
+    const objekt = filteredAndSortedObjekts[index];
+    if (!objekt || !objekt.id) return;
+    setClosedIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(objekt.id as string)) {
+        newSet.delete(objekt.id as string);
+      } else {
+        newSet.add(objekt.id as string);
+      }
+      return newSet;
+    });
   };
 
   const filteredAndSortedObjekts = useMemo(() => {
@@ -61,7 +71,7 @@ export default function OperatingObjekteItemDocAccordion({
           </p>
           {filteredAndSortedObjekts.map((objekt, index) => (
             <OperatingObjekteItemDocWithHistory
-              isOpen={openIndex === index}
+              isOpen={!closedIds.has(objekt.id as string)}
               onClick={handleClick}
               key={objekt.id}
               index={index}


### PR DESCRIPTION
# PR Description: Fix Data Missing & Visually Differentiate Heating Bill History

**What was changed**
- Added a new API hook [useAllHeatingBillDocumentsByObjektID](cci:1://file:///Users/Kareem/Code/Code/Heidi/paul/src/apiClient/index.ts:568:0-575:1) to fetch all heating bill documents for a specific objekt, regardless of whether they have a `local_id` or their `submited` status.
- Updated the heating bill object history components ([ObjekteItemDocWithHistory](cci:1://file:///Users/Kareem/Code/Code/Heidi/paul/src/components/Admin/ObjekteItem/ObjekteItemDocWithHistory.tsx:25:0-126:1) and [AdminHeatObjekteItemDocWithHistory](cci:1://file:///Users/Kareem/Code/Code/Heidi/paul/src/components/Admin/ObjekteItem/Admin/AdminHeatObjekteItemDocWithHistory.tsx:26:0-128:1)) to use this new hook, replacing [useHeatingBillBuildingDocumentsByObjektID](cci:1://file:///Users/Kareem/Code/Code/Heidi/paul/src/apiClient/index.ts:545:0-552:1).
- Implemented visual differentiation: submitted documents now display a `green_check_circle` icon, while draft documents continue to use the `operating_cost_documents_pending` icon.
- Implemented behavioral differentiation for history list links:
    - **Submitted documents**: Redirect to the results page (`.../[objekt_id]/[doc_id]/results`).
    - **Draft documents (Building-level)**: Redirect to continue editing at the object level (`.../objektauswahl/weitermachen/[doc_id]/abrechnungszeitraum`).
    - **Draft documents (Local-level)**: Redirect to continue editing at the local level (`.../localauswahl/weitermachen/[doc_id]/abrechnungszeitraum`).
- Modified all Heating Cost (`Heizkostenabrechnung`) and Operating Cost (`Betriebskostenabrechnung`) document lists to be expanded by default. This was done by replacing the single `openIndex` state with a `closedIds` Set state in the accordion components (Admin and Non-Admin variants).

**Why it was changed**
- The previous implementation used [useHeatingBillBuildingDocumentsByObjektID](cci:1://file:///Users/Kareem/Code/Code/Heidi/paul/src/apiClient/index.ts:545:0-552:1), which applied a filter (`local_id IS NULL`) that intentionally hid any heating bill documents created for specific locals (i.e. those created via the `localauswahl` fallback flow). This made it appear as though no data existed.
- Documents that had already been submitted were also excluded from the list entirely.
- The user experience was confusing as all history links defaulted to the "continue editing" ([weitermachen](cci:7://file:///Users/Kareem/Code/Code/Heidi/paul/src/app/%28admin%29/heizkostenabrechnung/localauswahl/weitermachen:0:0-0:0)) route, even for fully submitted documents. There was no visual indicator separating drafts from submitted forms.
- Previously, users had to manually click to expand each property to see its documents. Expanding the lists by default provides a much better user experience so users instantly see their document history.

**Any impact on CI, deployments, or infrastructure**
- No impact. This is purely a UI and routing logic change on the frontend supported by a new Supabase client-side query.

**Any required follow-up actions**
- None currently required. Reviewers should verify the routing logic behaves as expected for both Admin and Non-Admin variants, and ensure the default expanded state functions smoothly.
