### PR TITLE
feat: Refine heating bill initiator lookup logic and enhance Slack no…

### DIFF
--- a/src/app/api/heating-bill/generate/batch/route.ts
+++ b/src/app/api/heating-bill/generate/batch/route.ts
@@ -443,7 +443,9 @@ async function processBatchInBackground(
                 .then((r) => r[0] ?? null));
         const ownerUserId = objektRow?.user_id ?? null;
         const rawUserId = raw?.user?.id;
-        const needsInitiatorLookup = !raw?.user;
+        // Only skip the initiator lookup if raw.user IS the initiator (same userId).
+        // When an admin generates for a client, raw.user is the client, not the admin.
+        const needsInitiatorLookup = rawUserId !== userId;
         const needsOwnerLookup = Boolean(
             ownerUserId && rawUserId !== ownerUserId
         );
@@ -477,13 +479,14 @@ async function processBatchInBackground(
                 ownerRow = userRowsById.get(ownerUserId) ?? null;
             }
         }
-        if (raw?.user) {
-            userName =
-                `${raw.user.first_name ?? ""} ${raw.user.last_name ?? ""}`.trim() ||
-                userName;
-        } else if (initiatorRow) {
+        if (initiatorRow) {
             userName =
                 `${initiatorRow.first_name ?? ""} ${initiatorRow.last_name ?? ""}`.trim() ||
+                userName;
+        } else if (raw?.user && rawUserId === userId) {
+            // raw.user is the initiator — use it directly (no separate lookup needed)
+            userName =
+                `${raw.user.first_name ?? ""} ${raw.user.last_name ?? ""}`.trim() ||
                 userName;
         }
         if (ownerRow) {
@@ -538,7 +541,7 @@ async function processBatchInBackground(
         }
     }
 
-    await sendHeatingBillNotification(
+   await sendHeatingBillNotification(
         {
             docId,
             userId,
@@ -566,7 +569,7 @@ async function processBatchInBackground(
         failed,
         totalLocals: locals.length,
         apartments,
-        failedEntries,
+        failedEntries, 
     };
 }
 

--- a/src/lib/slackNotifications.ts
+++ b/src/lib/slackNotifications.ts
@@ -65,6 +65,20 @@ type SlackWebhookPayload = {
   icon_emoji?: string;
 };
 
+/** Sanitize text used as the display portion of a Slack `<URL|text>` hyperlink.
+ * Special characters break Slack's mrkdwn link format:
+ * - `>` closes the hyperlink tag prematurely
+ * - `|` adds a spurious pipe that ends the display text early
+ * - newlines inside the format string break rendering
+ */
+function sanitizeSlackLinkText(text: string): string {
+  return text
+    .replaceAll(/[\r\n]+/g, " ")
+    .replaceAll("|", "-")
+    .replaceAll(">", "&gt;")
+    .replaceAll("<", "&lt;");
+}
+
 /** Label for hyperlinks: floor + living space concatenated. */
 function buildApartmentLinkLabel(apt: {
   floor?: string | null;
@@ -175,14 +189,14 @@ export async function sendHeatingBillNotification(
           const isLeerstand = tenant.contractId.startsWith("leerstand_");
           const tenantIcon = isLeerstand ? "🏚️" : "👤";
           if (tenant.presignedUrl) {
-            lines.push(`${tenantIcon} <${tenant.presignedUrl}|${tenant.contractorsNames}>`);
+            lines.push(`${tenantIcon} <${tenant.presignedUrl}|${sanitizeSlackLinkText(tenant.contractorsNames)}>`);
           } else {
             lines.push(`${tenantIcon} ${tenant.contractorsNames}`);
           }
         }
       } else {
         if (apt.presignedUrl) {
-          lines.push(`• <${apt.presignedUrl}|${aptLabel}>`);
+          lines.push(`• <${apt.presignedUrl}|${sanitizeSlackLinkText(aptLabel)}>`);
         } else {
           lines.push(`• ${aptLabel}`);
         }
@@ -203,13 +217,13 @@ export async function sendHeatingBillNotification(
         lines.push(`• *${label}*`);
         for (const tenant of apt.tenants) {
           if (tenant.presignedUrl) {
-            lines.push(`<${tenant.presignedUrl}|${tenant.contractorsNames}>`);
+            lines.push(`<${tenant.presignedUrl}|${sanitizeSlackLinkText(tenant.contractorsNames)}>`);
           } else {
             lines.push(`${tenant.contractorsNames}`);
           }
         }
       } else if (apt.presignedUrl) {
-        lines.push(`• <${apt.presignedUrl}|${label}>`);
+        lines.push(`• <${apt.presignedUrl}|${sanitizeSlackLinkText(label)}>`);
       } else {
         lines.push(`• ${label}`);
       }
@@ -218,26 +232,46 @@ export async function sendHeatingBillNotification(
 
   // Slack truncates messages over ~4000 chars. Split into chunks and send
   // each as a separate webhook call to avoid losing tenant PDF links.
-  const fullText = lines.join("\n");
+  // Group apartment-header lines with their tenant sub-lines so a header
+  // is never stranded in one message while its PDF links land in another.
   const MAX_CHUNK = 3900;
-  const chunks: string[] = [];
 
-  if (fullText.length <= MAX_CHUNK) {
-    chunks.push(fullText);
-  } else {
-    // Split on line boundaries, keeping each chunk under the limit
-    let current = "";
-    for (const line of lines) {
-      const candidate = current ? `${current}\n${line}` : line;
-      if (candidate.length > MAX_CHUNK && current) {
-        chunks.push(current);
-        current = line;
-      } else {
-        current = candidate;
+  // Build groups: each apartment header + its tenant lines form one group.
+  // All other lines (header, summary, etc.) are individual single-line groups.
+  const groups: string[][] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    // Apartment headers look like "• *label* (N PDF…)" – gather the lines that follow
+    // (tenant/failed lines) until the next header or non-child line.
+    if (line.startsWith("• *") && line.includes("PDF")) {
+      const group = [line];
+      i++;
+      while (i < lines.length && (lines[i].startsWith("👤 ") || lines[i].startsWith("🏚️ "))) {
+        group.push(lines[i]);
+        i++;
       }
+      groups.push(group);
+    } else {
+      groups.push([line]);
+      i++;
     }
-    if (current) chunks.push(current);
   }
+
+  // Fill chunks, never splitting a group across chunk boundaries.
+  const chunks: string[] = [];
+  let current = "";
+  for (const group of groups) {
+    const groupText = group.join("\n");
+    const candidate = current ? `${current}\n${groupText}` : groupText;
+    if (candidate.length > MAX_CHUNK && current) {
+      chunks.push(current);
+      current = groupText;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push(current);
 
   for (const chunk of chunks) {
     const payload: SlackWebhookPayload = {


### PR DESCRIPTION
# fix: Heating bill Slack notification — broken PDF links & wrong initiator name

## What was changed

### 1. `src/lib/slackNotifications.ts`

**Added `sanitizeSlackLinkText` helper**

A new function strips characters from tenant/apartment names that break Slack's `<URL|text>` hyperlink format before they are embedded in notification messages:

| Character | Problem | Replacement |
|-----------|---------|-------------|
| `>` | Prematurely closes the hyperlink tag | `&gt;` |
| `\|` | Terminates display text early, leaving trailing garbage | `-` |
| `\r\n` | Embedded newlines split the link visually | space |
| `<` | Opens a nested tag | `&lt;` |

Applied at all four link construction sites (batch mode tenant lines, batch mode legacy single-PDF lines, single mode tenant lines, single mode legacy single-PDF lines).

**Replaced line-by-line chunker with group-aware chunker**

Slack messages over ~3,900 characters are split into multiple webhook calls. The previous splitter iterated over individual lines, which could push an apartment header (`• *Floor • 90 qm* (2 PDFs)`) into chunk N while its tenant PDF links landed in chunk N+1 — making the links appear context-free and broken.

The new splitter first assembles **apartment groups** (header line + all immediately following tenant/vacant-unit lines) and treats each group as an atomic unit. A group is never split across chunks; if it does not fit in the current chunk it is moved entirely to the next one.

---

### 2. `src/app/api/heating-bill/generate/batch/route.ts`

**Fixed "Initiated by" showing the customer's name instead of the admin's**

When an admin generates a heating bill on behalf of a client, `raw.user` is the **client's** user record (sourced from the heating bill document), not the admin's. The previous logic used `needsInitiatorLookup = !raw?.user`, so whenever `raw.user` existed (i.e. always for a client-owned document) the admin's profile was never fetched and `userName` was incorrectly set to the client's name.

Fix: changed the condition to `rawUserId !== userId`. This ensures the logged-in user is always looked up separately when `raw.user` belongs to a different person. The `userName` assignment now prioritises the freshly-fetched `initiatorRow` and falls back to `raw.user` only when its `id` matches the initiator's `userId`.

---

## Why it was changed

- **Broken PDF links**: Tenant names containing `>`, `|`, or newline characters caused Slack's mrkdwn parser to misinterpret the hyperlink format, rendering unclickable or visually broken links in the notification channel.
- **Split-context links**: Long buildings (10+ apartments) triggered multi-message splitting that separated apartment labels from their PDF links, making links appear orphaned.
- **Wrong initiator identity**: Admins generating bills for clients were shown as the client in the "Initiated by" field, hiding audit trail visibility of who actually triggered the generation.

---

## Impact on CI, deployments, or infrastructure

- **No schema changes** — no database migrations required.
- **No new environment variables** — no infrastructure changes.
- **No API contract changes** — `sendHeatingBillNotification` signature is unchanged; callers are unaffected.
- **Slack webhook behaviour** — messages are still sent to the same webhook; the only observable difference is correct link rendering and correct initiator names.
- **Performance** — the group-aware chunker is O(n) on the number of lines, identical to the previous approach.

---

## Required follow-up actions

- [ ] Verify in staging: generate a heating bill as an admin for a client and confirm the Slack notification shows the admin's name under "Initiated by" and the client's name under "Customer".
- [ ] Verify in staging: trigger a generation for a building with a tenant whose name contains `>` or `|` and confirm all PDF links are clickable.
- [ ] Verify in staging: trigger a generation for a large building (10+ apartments) that produces a multi-part Slack message and confirm apartment headers and their PDF links appear in the same message part.
- [ ] Apply the same `sanitizeSlackLinkText` fix to the **single-bill** route (`src/app/api/heating-bill/generate/route.ts`) if it constructs Slack links independently — quick audit recommended.
