### PR TITLE
feat: Introduce a pending state for heating bill documents, disabling…

### DIFF
--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
@@ -50,6 +50,16 @@ export default async function ResultLocalPDF({
   const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
     new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
+  let pendingTooltip = "";
+  if (isPdfPending && hbDoc?.created_at) {
+    const remainingMs = new Date(hbDoc.created_at).getTime() + 24 * 60 * 60 * 1000 - Date.now();
+    const hours = Math.floor(remainingMs / (60 * 60 * 1000));
+    const minutes = Math.ceil((remainingMs % (60 * 60 * 1000)) / (60 * 1000));
+    pendingTooltip = hours > 0
+      ? `Verfügbar in ${hours} Std. ${minutes} Min.`
+      : `Verfügbar in ${minutes} Min.`;
+  }
+
   let locals = (await getRelatedLocalsByObjektId(objekt_id)).filter((local) =>
     ALLOWED_HEATING_BILL_USAGE_TYPES.has(local.usage_type as UnitType)
   );
@@ -167,6 +177,8 @@ export default async function ResultLocalPDF({
                 status={status}
                 tenantDocuments={isPdfPending ? [] : (tenantDocsByLocalId[local.id ?? ""] ?? [])}
                 isSuperAdmin={isSuperAdmin}
+                isPending={isPdfPending}
+                pendingTooltip={pendingTooltip}
               />
             ))
           )}

--- a/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx
@@ -38,6 +38,16 @@ export default async function ResultLocalPDF({
   const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
     new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
+  let pendingTooltip = "";
+  if (isPdfPending && hbDoc?.created_at) {
+    const remainingMs = new Date(hbDoc.created_at).getTime() + 24 * 60 * 60 * 1000 - Date.now();
+    const hours = Math.floor(remainingMs / (60 * 60 * 1000));
+    const minutes = Math.ceil((remainingMs % (60 * 60 * 1000)) / (60 * 1000));
+    pendingTooltip = hours > 0
+      ? `Verfügbar in ${hours} Std. ${minutes} Min.`
+      : `Verfügbar in ${minutes} Min.`;
+  }
+
   const [localData, documentsByLocalId, contracts] = await Promise.all([
     getLocalById(local_id),
     getDocumentsByHeatingBillDocId(doc_id),
@@ -91,6 +101,8 @@ export default async function ResultLocalPDF({
           docID={doc_id}
           docType="localauswahl"
           tenantDocuments={isPdfPending ? [] : tenantDocuments}
+          isPending={isPdfPending}
+          pendingTooltip={pendingTooltip}
         />
       </ContentWrapper>
     </div>

--- a/src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx
@@ -49,6 +49,16 @@ export default async function ResultLocalPDF({
   const isPdfPending = !isSuperAdmin && !!hbDoc?.created_at &&
     new Date(hbDoc.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000);
 
+  let pendingTooltip = "";
+  if (isPdfPending && hbDoc?.created_at) {
+    const remainingMs = new Date(hbDoc.created_at).getTime() + 24 * 60 * 60 * 1000 - Date.now();
+    const hours = Math.floor(remainingMs / (60 * 60 * 1000));
+    const minutes = Math.ceil((remainingMs % (60 * 60 * 1000)) / (60 * 1000));
+    pendingTooltip = hours > 0
+      ? `Verfügbar in ${hours} Std. ${minutes} Min.`
+      : `Verfügbar in ${minutes} Min.`;
+  }
+
   let locals = (await getRelatedLocalsByObjektId(objekt_id)).filter((local) =>
     ALLOWED_HEATING_BILL_USAGE_TYPES.has(local.usage_type as UnitType)
   );
@@ -168,6 +178,8 @@ export default async function ResultLocalPDF({
                   docID={doc_id}
                   status={status}
                   tenantDocuments={isPdfPending ? [] : (tenantDocsByLocalId[local.id ?? ""] ?? [])}
+                  isPending={isPdfPending}
+                  pendingTooltip={pendingTooltip}
                 />
               ))
             )}

--- a/src/components/Admin/ObjekteLocalItem/Admin/AdminObjekteLocalItemHeatingBillDocResult.tsx
+++ b/src/components/Admin/ObjekteLocalItem/Admin/AdminObjekteLocalItemHeatingBillDocResult.tsx
@@ -27,6 +27,8 @@ export type ObjekteLocalItemHeatingBillDocResultProps = {
   status?: "renting" | "vacancy";
   tenantDocuments?: TenantDocument[];
   isSuperAdmin?: boolean;
+  isPending?: boolean;
+  pendingTooltip?: string;
 };
 
 export default async function AdminObjekteLocalItemHeatingBillDocResult({
@@ -38,6 +40,8 @@ export default async function AdminObjekteLocalItemHeatingBillDocResult({
   status: statusFromProps,
   tenantDocuments = [],
   isSuperAdmin = false,
+  isPending = false,
+  pendingTooltip,
 }: Readonly<ObjekteLocalItemHeatingBillDocResultProps>) {
   let status = statusFromProps;
   if (!status) {
@@ -144,8 +148,15 @@ export default async function AdminObjekteLocalItemHeatingBillDocResult({
           </div>
         </div>
         <div className="flex items-center gap-4">
+          {/* Pending placeholder actions */}
+          {isPending && (
+            <TenantDocumentActions
+              isPending
+              pendingTooltip={pendingTooltip}
+            />
+          )}
           {/* Inline action buttons when single document */}
-          {singleDoc && (
+          {!isPending && singleDoc && (
             <div className="flex items-center gap-2">
               {!singleDoc.current_document && (
                 <span className="text-xs text-red-600 bg-red-50 px-2 py-0.5 rounded-full whitespace-nowrap hidden medium:inline-block">
@@ -158,7 +169,7 @@ export default async function AdminObjekteLocalItemHeatingBillDocResult({
               />
             </div>
           )}
-          {singleDoc && isSuperAdmin ? (
+          {!isPending && singleDoc && isSuperAdmin ? (
             <TenantDocumentUploadHandler
               documentId={singleDoc.id}
               editLink={editLink}

--- a/src/components/Admin/ObjekteLocalItem/Admin/TenantDocumentActions.tsx
+++ b/src/components/Admin/ObjekteLocalItem/Admin/TenantDocumentActions.tsx
@@ -6,17 +6,22 @@ import Link from "next/link";
 import { pdf_icon, doc_download, gmail } from "@/static/icons";
 
 export type TenantDocumentActionsProps = {
-    documentId: string;
-    previewHref: string;
+    documentId?: string;
+    previewHref?: string;
+    isPending?: boolean;
+    pendingTooltip?: string;
 };
 
 export default function TenantDocumentActions({
     documentId,
     previewHref,
+    isPending = false,
+    pendingTooltip,
 }: Readonly<TenantDocumentActionsProps>) {
     const [loading, setLoading] = useState(false);
 
     const handleDownload = async () => {
+        if (!documentId) return;
         try {
             setLoading(true);
             const res = await fetch(`/api/heating-bill/document-url/${documentId}`);
@@ -46,10 +51,57 @@ export default function TenantDocumentActions({
         }
     };
 
+    if (isPending) {
+        return (
+            <div className="relative group flex items-center gap-3 max-medium:gap-2 flex-shrink-0">
+                <div className="flex items-center gap-3 max-medium:gap-2 opacity-40 pointer-events-none cursor-not-allowed">
+                    <span className="inline-flex">
+                        <Image
+                            width={0}
+                            height={0}
+                            sizes="100vw"
+                            loading="lazy"
+                            className="max-w-8 max-h-8 max-xl:max-w-5 max-xl:max-h-5 max-medium:max-w-6 max-medium:max-h-6"
+                            src={pdf_icon}
+                            alt="preview"
+                        />
+                    </span>
+                    <span className="inline-flex">
+                        <Image
+                            width={0}
+                            height={0}
+                            sizes="100vw"
+                            loading="lazy"
+                            className="max-w-8 max-h-8 max-xl:max-w-5 max-xl:max-h-5 max-medium:max-w-6 max-medium:max-h-6"
+                            src={doc_download}
+                            alt="download"
+                        />
+                    </span>
+                    <span className="inline-flex">
+                        <Image
+                            width={0}
+                            height={0}
+                            sizes="100vw"
+                            loading="lazy"
+                            className="max-w-7 max-h-7 max-xl:max-w-5 max-xl:max-h-5 max-medium:max-w-6 max-medium:max-h-6"
+                            src={gmail}
+                            alt="email"
+                        />
+                    </span>
+                </div>
+                {pendingTooltip && (
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                        {pendingTooltip}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
     return (
         <div className="flex items-center gap-3 max-medium:gap-2 flex-shrink-0">
             <span className="inline-flex">
-                <Link href={previewHref}>
+                <Link href={previewHref ?? "#"}>
                     <Image
                         width={0}
                         height={0}

--- a/src/components/Admin/ObjekteLocalItem/ObjekteLocalItemHeatingBillDocResult.tsx
+++ b/src/components/Admin/ObjekteLocalItem/ObjekteLocalItemHeatingBillDocResult.tsx
@@ -14,6 +14,8 @@ export type ObjekteLocalItemHeatingBillDocResultProps = {
   docID?: string;
   docType: "localauswahl" | "objektauswahl";
   tenantDocuments?: TenantDocument[];
+  isPending?: boolean;
+  pendingTooltip?: string;
 };
 
 export default async function ObjekteLocalItemHeatingBillDocResult({
@@ -22,7 +24,9 @@ export default async function ObjekteLocalItemHeatingBillDocResult({
   docID,
   docType,
   tenantDocuments = [],
-}: ObjekteLocalItemHeatingBillDocResultProps) {
+  isPending = false,
+  pendingTooltip,
+}: Readonly<ObjekteLocalItemHeatingBillDocResultProps>) {
   const contracts = await getContractsWithContractorsByLocalID(item.id);
 
   const status = contracts?.some((contract) => contract.is_current)
@@ -101,8 +105,15 @@ export default async function ObjekteLocalItemHeatingBillDocResult({
           </div>
         </div>
         <div className="flex items-center gap-4">
+          {/* Pending placeholder actions */}
+          {isPending && (
+            <TenantDocumentActions
+              isPending
+              pendingTooltip={pendingTooltip}
+            />
+          )}
           {/* Inline action buttons when single document */}
-          {singleDoc && (
+          {!isPending && singleDoc && (
             <TenantDocumentActions
               documentId={singleDoc.id}
               previewHref={`${previewBaseHref}?documentId=${singleDoc.id}`}

--- a/src/components/Admin/ObjekteLocalItem/ObjekteObjektItemHeatingBillDocResult.tsx
+++ b/src/components/Admin/ObjekteLocalItem/ObjekteObjektItemHeatingBillDocResult.tsx
@@ -20,6 +20,8 @@ export type ObjekteLocalItemHeatingBillDocResultProps = {
   docType: "localauswahl" | "objektauswahl";
   status?: "renting" | "vacancy";
   tenantDocuments?: TenantDocument[];
+  isPending?: boolean;
+  pendingTooltip?: string;
 };
 
 export default function ObjekteObjektItemHeatingBillDocResult({
@@ -29,6 +31,8 @@ export default function ObjekteObjektItemHeatingBillDocResult({
   docType,
   status = "vacancy",
   tenantDocuments = [],
+  isPending = false,
+  pendingTooltip,
 }: Readonly<ObjekteLocalItemHeatingBillDocResultProps>) {
   const handleStatusImage = () => {
     switch (status) {
@@ -105,8 +109,15 @@ export default function ObjekteObjektItemHeatingBillDocResult({
           </div>
         </div>
         <div className="flex items-center gap-4">
+          {/* Pending placeholder actions */}
+          {isPending && (
+            <TenantDocumentActions
+              isPending
+              pendingTooltip={pendingTooltip}
+            />
+          )}
           {/* Inline action buttons when single document */}
-          {singleDoc && (
+          {!isPending && singleDoc && (
             <TenantDocumentActions
               documentId={singleDoc.id}
               previewHref={`${previewBaseHref}?documentId=${singleDoc.id}`}


### PR DESCRIPTION
# feat: Show greyed-out PDF actions with availability tooltip for pending heating bills

## What was changed

When a heating bill document is in the pending state (created within the last 24 hours, PDFs still being generated), the results list previously hid all action buttons entirely. This PR changes that behaviour so that the preview, download, and email action icons are always visible but rendered as greyed-out, non-interactive placeholders. Hovering over them displays a tooltip indicating how much time remains until the PDFs become available (e.g. "Verfügbar in 18 Std. 30 Min.").

This applies to all three results views:
- Non-admin: `/heizkostenabrechnung/objektauswahl/.../results`
- Admin: `/admin/[user_id]/heizkostenabrechnung/objektauswahl/.../results`
- Non-admin localauswahl: `/heizkostenabrechnung/localauswahl/.../results`

### Files modified

| File | Change |
|------|--------|
| `src/components/Admin/ObjekteLocalItem/Admin/TenantDocumentActions.tsx` | Added `isPending` and `pendingTooltip` props. When pending, renders greyed-out non-interactive icons with a Tailwind `group-hover` tooltip positioned above. |
| `src/components/Admin/ObjekteLocalItem/ObjekteObjektItemHeatingBillDocResult.tsx` | Added `isPending` / `pendingTooltip` props. Renders pending placeholder actions when `isPending=true`, regardless of whether tenant documents exist. |
| `src/components/Admin/ObjekteLocalItem/Admin/AdminObjekteLocalItemHeatingBillDocResult.tsx` | Same as above for the admin variant. |
| `src/components/Admin/ObjekteLocalItem/ObjekteLocalItemHeatingBillDocResult.tsx` | Same as above for the localauswahl variant. |
| `src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx` | Computes `pendingTooltip` time-remaining string and passes `isPending` + `pendingTooltip` down to the list component. |
| `src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/page.tsx` | Same as above for the admin route. |
| `src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/page.tsx` | Same as above for the localauswahl route. |

## Why it was changed

Previously, users landing on the results page while PDFs were still being generated would see list rows with no actions at all — no indication that actions would eventually be available. This was confusing UX. The change makes it immediately clear that PDF actions exist and will become available, without allowing users to attempt interactions that would fail.

The pending window is unchanged: 24 hours from `heating_bill_documents.created_at`. Super admins bypass the pending state as before and see fully functional actions immediately.

## Impact on CI, deployments, or infrastructure

- **No database changes.** No new queries, schema changes, or migrations.
- **No new dependencies.** Tooltip is implemented using existing Tailwind utility classes (`group`, `group-hover`, `opacity-0/100`, `transition-opacity`), consistent with patterns already used in the codebase.
- **No API changes.** The `/api/heating-bill/document-url/[documentId]` endpoint is untouched.
- **No environment variable changes.**
- **Purely frontend / UI change.** Safe to deploy independently.

## Required follow-up actions

- None required. The admin localauswahl route (`/admin/[user_id]/heizkostenabrechnung/localauswahl/...`) was not found in the codebase and does not appear to exist — no changes were needed there.
- If the 24-hour pending window is ever made configurable, the `pendingTooltip` calculation in all three page files should be updated accordingly.