### PR TITLE
fix: HCA device categorization and timezone mismatch in shared dashboard

### DIFF
--- a/src/app/shared/dashboard/SharedDashboardWrapper.tsx
+++ b/src/app/shared/dashboard/SharedDashboardWrapper.tsx
@@ -18,11 +18,21 @@ interface SharedDashboardWrapperProps {
 }
 
 export default function SharedDashboardWrapper({ filteredData, filters }: SharedDashboardWrapperProps) {
-  const { setDates, setMeterIds } = useChartStore();
+  const { setDates, setMeterIds, startDate, endDate } = useChartStore();
+  
+  // Parse URL dates once (now handles full ISO timestamps like "2025-08-31T22:00:00.000Z")
+  const urlStartDate = filters.startDate ? new Date(filters.startDate) : null;
+  const urlEndDate = filters.endDate ? new Date(filters.endDate) : null;
+  
+  // Check if store dates match URL dates (comparing ISO strings for exact match)
+  const datesMatch = startDate?.toISOString() === urlStartDate?.toISOString() &&
+                     endDate?.toISOString() === urlEndDate?.toISOString();
   
   useEffect(() => {
-    if (filters.startDate && filters.endDate) {
-      setDates(new Date(filters.startDate), new Date(filters.endDate));
+    // FIX: Set dates from URL (now with full ISO timestamps for exact UTC match)
+    // This ensures tenant sees identical data as landlord regardless of timezone
+    if (urlStartDate && urlEndDate && !datesMatch) {
+      setDates(urlStartDate, urlEndDate);
     }
     
     // For shared dashboard, we need to set the device serial numbers (not UUIDs)
@@ -37,19 +47,20 @@ export default function SharedDashboardWrapper({ filteredData, filters }: Shared
     } else if (filters.meterIds) {
       setMeterIds(filters.meterIds);
     }
-  }, [filters, filteredData, setDates, setMeterIds]);
+  }, [filters, filteredData, setDates, setMeterIds, urlStartDate, urlEndDate, datesMatch]);
 
   const { heatDevices, coldWaterDevices, hotWaterDevices, electricityDevices } = useMemo(() => {
     return (filteredData || []).reduce(
       (acc, item) => {
         const deviceType = item["Device Type"];
         // Support both OLD format and NEW Engelmann format device types
-        // Must match exactly what useChartData.ts uses
-        if (deviceType === "Heat" || deviceType === "Heizkostenverteiler" || deviceType === "WMZ Rücklauf" || deviceType === "Wärmemengenzähler") {
+        // Must match exactly what useDashboardData.ts uses
+        // HCA = Heat Cost Allocator (Heizkostenverteiler) - belongs to heat, NOT hot water!
+        if (deviceType === "Heat" || deviceType === "HCA" || deviceType === "Heizkostenverteiler" || deviceType === "WMZ Rücklauf" || deviceType === "Wärmemengenzähler") {
           acc.heatDevices.push(item);
         } else if (deviceType === "Water" || deviceType === "Kaltwasserzähler") {
           acc.coldWaterDevices.push(item);
-        } else if (deviceType === "WWater" || deviceType === "Warmwasserzähler"|| deviceType === "HCA") {
+        } else if (deviceType === "WWater" || deviceType === "Warmwasserzähler") {
           acc.hotWaterDevices.push(item);
         } else if (deviceType === "Elec" || deviceType === "Stromzähler") {
           acc.electricityDevices.push(item);

--- a/src/components/Basic/Dialog/ShareDashboardDialog.tsx
+++ b/src/components/Basic/Dialog/ShareDashboardDialog.tsx
@@ -67,11 +67,12 @@ export default function ShareDashboardDialog() {
 
       // Create filters from current dashboard state
       // Only include dates if they're actually set in the dashboard
-      // Use local date formatting to avoid timezone issues
+      // FIX: Use ISO timestamps to preserve exact UTC time - this ensures tenant sees
+      // identical data regardless of their timezone
       const filters: ShareFilters = {
         meterIds: meterIds.length > 0 ? meterIds : undefined,
-        startDate: formatLocalDate(startDate),
-        endDate: formatLocalDate(endDate),
+        startDate: safeStart?.toISOString(),  // Full UTC timestamp e.g., "2025-08-31T22:00:00.000Z"
+        endDate: safeEnd?.toISOString(),      // Full UTC timestamp e.g., "2025-09-30T21:59:59.999Z"
       };
 
       console.log('Filters being sent:', filters);

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -147,10 +147,11 @@ export const useHeatChartData = (): ChartDataHookResult => {
     setError(null);
 
     try {
-      // Support both OLD format ('Heat') and NEW format ('WMZ Rücklauf', 'Heizkostenverteiler', 'Wärmemengenzähler')
+      // Support both OLD format ('Heat', 'HCA') and NEW format ('WMZ Rücklauf', 'Heizkostenverteiler', 'Wärmemengenzähler')
+      // HCA = Heat Cost Allocator (Heizkostenverteiler) - must be included with heat devices
       const chartData = await fetchChartData(
         meterIds,
-        ['Heat', 'WMZ Rücklauf', 'Heizkostenverteiler', 'Wärmemengenzähler'],
+        ['Heat', 'HCA', 'WMZ Rücklauf', 'Heizkostenverteiler', 'Wärmemengenzähler'],
         startDate,
         endDate
       );

--- a/src/lib/sharedDashboardData.ts
+++ b/src/lib/sharedDashboardData.ts
@@ -140,16 +140,26 @@ export async function fetchSharedDashboardData(
     
     // CRITICAL: Adjust start date -7 days to get baseline readings for consumption calculation
     // Without this, consumption = current - previous will be incorrect due to missing baseline
+    // FIX: Handle both ISO timestamps ("2025-08-31T22:00:00.000Z") and date strings ("2025-09-01")
     let adjustedStartDate = startDate;
     if (startDate) {
       const date = new Date(startDate);
       date.setDate(date.getDate() - 7);
+      // Keep as date-only string for database query (RPC expects YYYY-MM-DD format)
       adjustedStartDate = date.toISOString().split('T')[0];
+    }
+    
+    // Also convert endDate to date-only format for database query
+    let adjustedEndDate = endDate;
+    if (endDate) {
+      const date = new Date(endDate);
+      adjustedEndDate = date.toISOString().split('T')[0];
     }
     
     logger.log('[SharedDashboard] Querying parsed_data with consolidated approach:');
     logger.log('  - local_meter_ids:', allMeterIds.length);
     logger.log('  - adjustedStartDate:', adjustedStartDate, '(original:', startDate, ')');
+    logger.log('  - adjustedEndDate:', adjustedEndDate, '(original:', endDate, ')');
     
     // Single RPC call with all device types
     const { data: parsedData, error } = await supabase.rpc('get_dashboard_data', {
@@ -163,7 +173,7 @@ export async function fetchSharedDashboardData(
         'Gateway'
       ],
       p_start_date: adjustedStartDate || null,
-      p_end_date: endDate || null
+      p_end_date: adjustedEndDate || null
     });
     
     if (error) {

--- a/src/store/useShareStore.ts
+++ b/src/store/useShareStore.ts
@@ -8,16 +8,13 @@ interface ShareStoreState {
   setShareUrl: (url: string) => void;
 }
 
-// Helper to format date as YYYY-MM-DD in local timezone (not UTC)
+// Helper to safely convert date to ISO string
 // Defensively handles strings (from Zustand persist rehydration) in addition to Date objects.
-const formatLocalDate = (date: Date | string | null | undefined): string | undefined => {
+const toISOString = (date: Date | string | null | undefined): string | undefined => {
   if (!date) return undefined;
   const d = date instanceof Date ? date : new Date(date);
   if (isNaN(d.getTime())) return undefined;
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  return d.toISOString(); // Full UTC timestamp e.g., "2025-08-31T22:00:00.000Z"
 };
 
 export const useShareStore = create<ShareStoreState>((set) => ({
@@ -28,11 +25,12 @@ export const useShareStore = create<ShareStoreState>((set) => ({
 
     const { startDate, endDate, meterIds } = useChartStore.getState();
 
-    // Use local date formatting to avoid timezone issues
+    // FIX: Use ISO timestamps to preserve exact UTC time - this ensures tenant sees
+    // identical data regardless of their timezone
     const filters: ShareFilters = {
       meterIds: meterIds.length > 0 ? meterIds : undefined,
-      startDate: formatLocalDate(startDate),
-      endDate: formatLocalDate(endDate),
+      startDate: toISOString(startDate),
+      endDate: toISOString(endDate),
     };
 
     const url = createShareableUrl(filters, 720); // 30 days


### PR DESCRIPTION
## Problem

1. **Heizkosten chart empty for tenants** - HCA (Heat Cost Allocator) devices were incorrectly categorized as hot water instead of heat, causing the Heizkosten chart to show "Keine Daten verfügbar"

2. **Timezone mismatch** - Landlord (Germany, UTC+2) and tenant (different timezone) could see different data for the same date range because share URLs used local date strings instead of UTC timestamps

## Root Cause

1. `SharedDashboardWrapper.tsx` had HCA in `hotWaterDevices` array instead of `heatDevices`
2. Share URL used local date strings (`"2025-09-01"`) which parse differently across timezones, instead of ISO timestamps (`"2025-08-31T22:00:00.000Z"`)

## Changes

| File | Change |
|------|--------|
| `SharedDashboardWrapper.tsx` | Move HCA from `hotWaterDevices` → `heatDevices` |
| `ShareDashboardDialog.tsx` | Use `toISOString()` for share URL dates |
| `useShareStore.ts` | Replace `formatLocalDate()` with `toISOString()` |
| `sharedDashboardData.ts` | Handle ISO timestamps in API, convert to date-only for DB |
| `useChartData.ts` | Add HCA to heat device filter (consistency) |