### PR TITLE
fix: meter deletion FK, admin dashboard cache, form labels

### DIFF
--- a/src/actions/create/createLocalMeters.ts
+++ b/src/actions/create/createLocalMeters.ts
@@ -5,6 +5,7 @@ import database from "@/db";
 import { local_meters } from "@/db/drizzle/schema";
 import { getAuthenticatedServerUser } from "@/utils/auth/server";
 import { eq, and } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 
 type MeterFormData = NonNullable<AdminEditObjekteUnitFormValues["meters"]>[number];
 
@@ -130,9 +131,35 @@ export async function createLocalMeters(
   );
 
   for (const meter of metersToDelete) {
-    await database
-      .delete(local_meters)
-      .where(eq(local_meters.id, meter.id));
+    try {
+      // Unlink parsed_data before delete to avoid FK violation (parsed_data.local_meter_id -> local_meters.id)
+      try {
+        await database.execute(
+          sql`UPDATE parsed_data SET local_meter_id = NULL WHERE local_meter_id = ${meter.id}`
+        );
+      } catch (unlinkErr) {
+        // parsed_data may not exist or have different schema; log and proceed with delete
+        console.warn(
+          "[createLocalMeters] Could not unlink parsed_data for meter:",
+          { meterId: meter.id, meterNumber: meter.meter_number },
+          unlinkErr
+        );
+      }
+      await database
+        .delete(local_meters)
+        .where(eq(local_meters.id, meter.id));
+    } catch (deleteErr) {
+      const message =
+        deleteErr instanceof Error ? deleteErr.message : String(deleteErr);
+      console.error(
+        "[createLocalMeters] Failed to delete meter:",
+        { meterId: meter.id, meterNumber: meter.meter_number, localID },
+        deleteErr
+      );
+      throw new Error(
+        `Zähler konnte nicht gelöscht werden (${meter.meter_number ?? meter.id}): ${message}`
+      );
+    }
   }
 
   // NOTE: We intentionally do NOT update locals.meter_ids here

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,7 +14,7 @@ import {
   heating_invoices,
   agencies,
 } from "@/db/drizzle/schema";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { supabaseServer } from "@/utils/supabase/server";
 import { isAdmin } from "@/auth";
 import { getAuthenticatedServerUser } from "@/utils/auth/server";
@@ -1193,7 +1193,8 @@ export async function getMetersByLocalIds(localIds: string[]): Promise<LocalMete
       created_at: local_meters.created_at,
     })
     .from(local_meters)
-    .where(inArray(local_meters.local_id, localIds));
+    .where(inArray(local_meters.local_id, localIds))
+    .orderBy(asc(local_meters.id));
 
   return meters;
 }

--- a/src/components/Admin/Forms/Admin/Create/AdminCreateObjekteUnitForm.tsx
+++ b/src/components/Admin/Forms/Admin/Create/AdminCreateObjekteUnitForm.tsx
@@ -176,7 +176,6 @@ export default function AdminCreateObjekteUnitForm({
   const house_location = methods.watch("house_location");
   const residential_area = methods.watch("residential_area");
   const living_space = methods.watch("living_space");
-  const heating_area = methods.watch("heating_area");
   const usage_type = methods.watch("usage_type");
 
   // Check if current type is non-residential
@@ -191,7 +190,6 @@ export default function AdminCreateObjekteUnitForm({
       house_location: house_location ?? undefined,
       residential_area: residential_area ?? undefined,
       living_space: String(living_space ?? 0),
-      heating_area: String(heating_area ?? 0),
     });
 
   return (

--- a/src/components/Admin/Forms/FormMetersField.tsx
+++ b/src/components/Admin/Forms/FormMetersField.tsx
@@ -174,7 +174,7 @@ export default function FormMetersField<T extends FieldValues = FieldValues>({
                     control={control}
                     className="min-w-0"
                     name={`meters.${index}.radiator_length` as Path<T>}
-                    label="Heizkörper Länge"
+                    label="Heizkörper Höhe"
                     placeholder="cm"
                     replaceDotWithComma
                   />

--- a/src/components/Basic/Charts/NotificationDetailModal.tsx
+++ b/src/components/Basic/Charts/NotificationDetailModal.tsx
@@ -19,6 +19,7 @@ export interface NotificationDetail {
     building?: string;
     unit?: string;
     tenant?: string;
+    totalDevices?: number;
 }
 
 interface NotificationDetailModalProps {
@@ -148,7 +149,13 @@ export default function NotificationDetailModal({ notification, onClose }: Notif
 
                     {/* Description */}
                     <div className="bg-gray-50 rounded-xl p-4">
-                        <p className="text-sm text-gray-600 leading-relaxed">{notification.subtitle}</p>
+                        {notification.title === "Alle Zähler funktionieren korrekt" ? (
+                            <p className="text-sm text-gray-600 leading-relaxed text-center">
+                                Alle {notification.totalDevices ?? notification.subtitle.match(/^(\d+)/)?.[1] ?? "—"} Zähler arbeiten einwandfrei und zeigen aktuell keine Fehlermeldungen an, sodass eine kontinuierliche und sichere Datenübermittlung gewährleistet ist. Darüber hinaus verfügen sämtliche installierten Heidi-Geräte über eine integrierte Speicherfunktion, die die Messdaten für einen Zeitraum von bis zu einem Jahr auch lokal speichert.
+                            </p>
+                        ) : (
+                            <p className="text-sm text-gray-600 leading-relaxed">{notification.subtitle}</p>
+                        )}
                     </div>
 
                     {/* Detail rows */}

--- a/src/components/Basic/Charts/NotificationGroupModal.tsx
+++ b/src/components/Basic/Charts/NotificationGroupModal.tsx
@@ -20,6 +20,7 @@ export interface GroupNotificationItem {
     building?: string;
     unit?: string;
     tenant?: string;
+    totalDevices?: number;
 }
 
 interface NotificationGroupModalProps {

--- a/src/components/Basic/Charts/NotificationItem.tsx
+++ b/src/components/Basic/Charts/NotificationItem.tsx
@@ -19,7 +19,7 @@ export default function NotificationItem({
 	subtitle,
 }: NotificationItemProps) {
 	return (
-		<div className="flex items-start justify-start gap-2 w-full p-1">
+		<div className="flex items-center justify-start gap-2 w-full p-1 min-h-[52px] max-md:min-h-12 max-lg:min-h-14">
 			<div className="flex items-center justify-start gap-2 flex-shrink-0">
 				<span
 					className="flex items-center justify-center w-[60px] h-[52px] max-md:w-12 max-md:h-12 max-lg:w-14 max-lg:h-14 rounded-sm"
@@ -50,9 +50,8 @@ export default function NotificationItem({
 					/>
 				</span>
 			</div>
-			<div className="flex-1 min-w-0">
-				{/* <p className="text-sm max-md:text-xs text-black/50 font-medium leading-tight">{title}</p> */}
-				<p className="text-sm max-lg:text-xs text-black/50 leading-tight overflow-hidden text-ellipsis line-clamp-3">
+			<div className="flex-1 min-w-0 flex items-center">
+				<p className="text-sm max-lg:text-xs text-black/50 leading-tight overflow-hidden text-ellipsis line-clamp-3 text-left w-full">
 					{subtitle}
 				</p>
 			</div>

--- a/src/components/Basic/Charts/NotificationsChart.tsx
+++ b/src/components/Basic/Charts/NotificationsChart.tsx
@@ -52,6 +52,7 @@ interface NotificationItem {
 	building?: string;
 	unit?: string;
 	tenant?: string;
+	totalDevices?: number;
 }
 
 interface NotificationsChartProps {
@@ -191,6 +192,7 @@ export default function NotificationsChart({
 			building: n.building,
 			unit: n.unit,
 			tenant: n.tenant,
+			totalDevices: n.totalDevices,
 		});
 		setOpenPopoverId(null);
 	};
@@ -475,15 +477,19 @@ export default function NotificationsChart({
 					parts.push(`${hotWaterDevices} Warmwasser`);
 				if (elecDevices > 0) parts.push(`${elecDevices} Strom`);
 
+				const subtitle =
+					parts.length > 0
+						? `${totalDevices} Geräte ohne Fehler (${parts.join(", ")})`
+						: `${totalDevices} Geräte ohne Fehler`;
+
 				dynamicNotifications.push({
 					leftIcon: notification,
 					rightIcon: green_check,
 					leftBg: "#E7E8EA",
 					rightBg: "#E7F2E8",
 					title: "Alle Zähler funktionieren korrekt",
-					subtitle: `${totalDevices} Geräte ohne Fehler (${parts.join(
-						", "
-					)})`,
+					subtitle,
+					totalDevices,
 				});
 
 				return dynamicNotifications;
@@ -726,6 +732,11 @@ export default function NotificationsChart({
 
 				// For demo account, skip success message and show dummy notifications instead
 				if (!isDemoAccount) {
+					const subtitle =
+						categoryParts.length > 0
+							? `${totalDevices} Geräte ohne Fehler (${categoryParts.join(", ")})`
+							: `${totalDevices} Geräte ohne Fehler`;
+
 					notifications.push({
 						leftIcon: getLeftIconForNotificationType(
 							"success",
@@ -735,9 +746,8 @@ export default function NotificationsChart({
 						leftBg: "#E7E8EA",
 						rightBg: "#E7F2E8",
 						title: "Alle Zähler funktionieren korrekt",
-						subtitle: `${totalDevices} Geräte ohne Fehler (${categoryParts.join(
-							", "
-						)})`,
+						subtitle,
+						totalDevices,
 					});
 
 					return notifications;
@@ -982,7 +992,7 @@ export default function NotificationsChart({
 							>
 								{/* Identical Layout to NotificationItem.tsx */}
 								<div className="flex-1 min-w-0">
-									<div className="flex items-start justify-start gap-2 w-full p-1">
+									<div className="flex items-center justify-start gap-2 w-full p-1 min-h-[52px] max-md:min-h-12 max-lg:min-h-14">
 										<div className="flex items-center justify-start gap-2 flex-shrink-0">
 											<span
 												className="flex items-center justify-center w-[60px] h-[52px] max-md:w-12 max-md:h-12 max-lg:w-14 max-lg:h-14 rounded-sm"
@@ -1013,11 +1023,11 @@ export default function NotificationsChart({
 												/>
 											</span>
 										</div>
-										<div className="flex-1 min-w-0 py-1">
-											<p className="text-sm font-medium text-gray-800 leading-tight truncate">
+										<div className="flex-1 min-w-0 py-1 flex flex-col justify-center">
+											<p className="text-sm font-medium text-gray-800 leading-tight truncate text-left w-full">
 												{group.items.length}x {group.label}...
 											</p>
-											<p className="text-sm max-lg:text-xs text-black/50 leading-tight truncate line-clamp-1 mt-0.5">
+											<p className="text-sm max-lg:text-xs text-black/50 leading-tight truncate line-clamp-1 mt-0.5 text-left w-full">
 												{group.title}
 											</p>
 										</div>

--- a/src/components/Header/AdminHeader/AdminApartmentsDropdown.tsx
+++ b/src/components/Header/AdminHeader/AdminApartmentsDropdown.tsx
@@ -28,11 +28,10 @@ export default function AdminApartmentsDropdown() {
   const { setMeterIds } = useChartStore();
 
   const isAdmin = !!resolvedUserId;
-
   const apartmentsToUse = isAdmin ? usersApartments : apartments;
   const isLoading = isAdmin ? isLoadingUsersApartments : isLoadingApartments;
   const error = isAdmin ? usersApartmentsError : apartmentsError;
-  
+
   // Log apartment data status
   console.log('[AdminApartmentsDropdown] Status:', {
     isAdmin,
@@ -44,11 +43,11 @@ export default function AdminApartmentsDropdown() {
 
   const toggleSelection = async (localId?: string) => {
     if (!localId) return;
-    
+
     const newSelectedIds = selectedLocalIds.includes(localId)
       ? selectedLocalIds.filter((id) => id !== localId)
       : [...selectedLocalIds, localId];
-      
+
     setSelectedLocalIds(newSelectedIds);
 
     // Update meter IDs based on new selection
@@ -86,6 +85,14 @@ export default function AdminApartmentsDropdown() {
       setMeterIds([]);
     }
   };
+
+  useEffect(() => {
+    // When viewing a customer's dashboard (resolvedUserId set), clear stale data first to prevent showing another user's persisted meterIds
+    if (resolvedUserId) {
+      setSelectedLocalIds([]);
+      setMeterIds([]);
+    }
+  }, [resolvedUserId]);
 
   useEffect(() => {
     // Only run selectAll when apartments data is loaded and not empty

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -1,17 +1,18 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
+import { useParams } from 'next/navigation';
 import { MeterReadingType } from '@/api';
 import { useChartStore } from '@/store/useChartStore';
 
 /**
  * Unified dashboard data hook with SWR caching
  * Fetches all device types in a single API call, then filters client-side
- * 
- * Benefits:
- * - 1 API call instead of 5
- * - Automatic deduplication (60s window)
- * - Shared cache across components
- * - Automatic revalidation
+ *
+ * Cache key design:
+ * - userId: Ensures admin viewing User B never gets User A's cached data
+ * - Sorted meterIds: DB returns meters in arbitrary order; sorting ensures same
+ *   set of meters always produces the same key regardless of array order
+ * - Date strings: Normalized to ISO date or 'null' for consistency
  */
 
 interface DashboardDataResult {
@@ -52,7 +53,7 @@ const fetchAllChartData = async (
         // OLD format
         'Heat', 'Water', 'WWater', 'Elec', 'HCA',
         // NEW Engelmann format
-        'Stromzähler', 'Kaltwasserzähler', 'Warmwasserzähler', 
+        'Stromzähler', 'Kaltwasserzähler', 'Warmwasserzähler',
         'WMZ Rücklauf', 'Heizkostenverteiler', 'Wärmemengenzähler'
       ],
       startDate: adjustedStartDate?.toISOString() || null,
@@ -68,19 +69,31 @@ const fetchAllChartData = async (
   return result.data || [];
 };
 
+/** Normalize date to ISO date string or 'null' for stable cache keys */
+function toDateKey(d: Date | null | undefined): string {
+  if (!d) return 'null';
+  const date = d instanceof Date ? d : new Date(d);
+  return isNaN(date.getTime()) ? 'null' : date.toISOString().split('T')[0];
+}
+
 export const useDashboardData = (): DashboardDataResult => {
+  const params = useParams();
   const { meterIds, startDate, endDate } = useChartStore();
 
-  // Create stable cache key
+  // User context: when admin views /admin/[user_id]/dashboard, this is the viewed user
+  const resolvedUserId = typeof params?.user_id === 'string' ? params.user_id : 'self';
+
+  // Stable cache key: userId + sorted meterIds + normalized dates
+  // - Sorted meterIds: same set of meters = same key regardless of array order from DB
+  // - userId: prevents serving wrong user's cache when admin switches customers
   const cacheKey = useMemo(() => {
     if (!meterIds.length) return null;
-    return [
-      'dashboard-data',
-      meterIds.join(','),
-      startDate?.toISOString() || 'null',
-      endDate?.toISOString() || 'null'
-    ];
-  }, [meterIds, startDate, endDate]);
+    const sortedIds = [...meterIds].filter(Boolean).sort();
+    const idsPart = sortedIds.join(',');
+    const startPart = toDateKey(startDate);
+    const endPart = toDateKey(endDate);
+    return `dashboard-data:${resolvedUserId}:${idsPart}:${startPart}:${endPart}`;
+  }, [resolvedUserId, meterIds, startDate, endDate]);
 
   // SWR with 60s deduplication window
   const { data: allData, error, mutate } = useSWR(

--- a/src/store/useChartStore.tsx
+++ b/src/store/useChartStore.tsx
@@ -48,9 +48,8 @@ export const useChartStore = create<ChartState>()(
 
       isTableView: false,
   setMeterIds: (ids: string[]) => {
-        set({
-          meterIds: ids?.length ? Array.from(new Set(ids)) : [],
-        });
+        const normalized = ids?.length ? Array.from(new Set(ids)).sort() : [];
+        set({ meterIds: normalized });
       },
 
       setDates: (start, end) => set({ startDate: start, endDate: end }),
@@ -58,12 +57,20 @@ export const useChartStore = create<ChartState>()(
     }),
     {
       name: "dashboard-chart-layout",
+      // Exclude meterIds from persist - they are user-specific; persisting causes wrong data when admin switches customers
+      partialize: (state) => ({
+        startDate: state.startDate,
+        endDate: state.endDate,
+        chartSizes: state.chartSizes,
+        isTableView: state.isTableView,
+      }),
       // Convert date strings back to Date objects after rehydration from localStorage
       merge: (persistedState, currentState) => {
         const persisted = (persistedState ?? {}) as Partial<ChartState>;
         return {
           ...currentState,
           ...persisted,
+          meterIds: [], // Always start empty; AdminApartmentsDropdown populates from current user's apartments
           startDate: toDateOrNull(persisted.startDate),
           endDate: toDateOrNull(persisted.endDate),
         };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -171,7 +171,6 @@ export const buildLocalName = ({
   house_location,
   residential_area,
   living_space,
-  heating_area,
 }: Partial<LocalType>) => {
   if (usage_type === "hallway" || usage_type === "staircase") {
     return "Treppenhaus";
@@ -185,17 +184,9 @@ export const buildLocalName = ({
     Boolean
   );
 
-  const heatingAreaNum = heating_area ? parseFloat(String(heating_area)) : 0;
-  const livingSpaceNum = living_space ? parseFloat(String(living_space)) : 0;
-
   const livingSpacePart = living_space ? `, ${String(living_space).replace(".", ",")}qm` : "";
 
-  const showHeatingPart = heatingAreaNum > 0 && heatingAreaNum !== livingSpaceNum;
-  const heatingSpacePart = showHeatingPart
-    ? `, ${String(heating_area).replace(".", ",")}qm`
-    : "";
-
-  return mainParts.join(" ") + livingSpacePart + heatingSpacePart;
+  return mainParts.join(" ") + livingSpacePart;
 };
 
 export const FUEL_COST_TYPES = ["fuel_costs", "brennstoffkosten"] as const;

--- a/src/utils/meterUtils.ts
+++ b/src/utils/meterUtils.ts
@@ -48,9 +48,10 @@ export const fetchMeterUUIDs = async (localIds: string[]): Promise<string[]> => 
 
     if (response.ok) {
       const { meters } = await response.json();
-      return meters
+      const ids = meters
         .map((meter: any) => meter.id)
         .filter((id: string) => Boolean(id));
+      return ids.sort();
     }
     return [];
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes meter deletion FK violations, dashboard cache/stale-data issues when admins switch customers, and notification UI. Simplifies `buildLocalName` and corrects form labels.

## Changes

### Meter & Database
- **createLocalMeters** – Unlink `parsed_data` before deleting meters to avoid FK violation; add error handling and user-facing error messages
- **getMetersByLocalIds** – Add `orderBy(asc(local_meters.id))` for stable meter ordering
- **fetchMeterUUIDs** – Sort returned meter IDs for consistent ordering

### Dashboard & Admin
- **AdminApartmentsDropdown** – Clear `selectedLocalIds` and `meterIds` when `resolvedUserId` changes to prevent showing another user's persisted data
- **useDashboardData** – Include `resolvedUserId` in cache key; sort `meterIds` for stable keys regardless of DB order
- **useChartStore** – Exclude `meterIds` from persist; always rehydrate with empty `meterIds` to avoid wrong-user data when admin switches customers

### Forms
- **buildLocalName** – Remove `heating_area` parameter and logic; simplify to living space only
- **AdminCreateObjekteUnitForm** – Stop passing `heating_area` to `buildLocalName`
- **FormMetersField** – Label fix: "Heizkörper Länge" → "Heizkörper Höhe"

### Notifications
- **NotificationDetailModal**, **NotificationGroupModal**, **NotificationItem**, **NotificationsChart** – Add `totalDevices`; custom success copy for "Alle Zähler funktionieren korrekt"; layout tweaks (min-height, alignment)

## Files Changed

| File | Changes |
|------|---------|
| `src/actions/create/createLocalMeters.ts` | Unlink parsed_data before delete, error handling |
| `src/api/index.ts` | orderBy for getMetersByLocalIds |
| `src/components/Admin/Forms/Admin/Create/AdminCreateObjekteUnitForm.tsx` | Remove heating_area from buildLocalName |
| `src/components/Admin/Forms/FormMetersField.tsx` | Label: Heizkörper Länge → Höhe |
| `src/components/Basic/Charts/NotificationDetailModal.tsx` | totalDevices, success message copy |
| `src/components/Basic/Charts/NotificationGroupModal.tsx` | totalDevices type |
| `src/components/Basic/Charts/NotificationItem.tsx` | Layout (min-height, alignment) |
| `src/components/Basic/Charts/NotificationsChart.tsx` | totalDevices, success subtitle, layout |
| `src/components/Header/AdminHeader/AdminApartmentsDropdown.tsx` | Clear selection when resolvedUserId changes |
| `src/hooks/useDashboardData.ts` | Cache key: userId + sorted meterIds |
| `src/store/useChartStore.tsx` | Exclude meterIds from persist |
| `src/utils/index.ts` | buildLocalName: remove heating_area |
| `src/utils/meterUtils.ts` | Sort meter IDs in fetchMeterUUIDs |

## Testing

- [ ] Admin dashboard – switch between customers; verify no stale meter data from previous user
- [ ] Admin objekt – edit unit, delete meters; verify no FK violation, error message on failure
- [ ] Create unit (Admin) – display name shows correctly without heating_area
- [ ] FormMetersField – radiator field label shows "Heizkörper Höhe"
- [ ] Notifications chart – "Alle Zähler funktionieren korrekt" shows correct copy and layout