### PR TITLE
Feat/dynamic pdfs v29

### DIFF
--- a/src/actions/delete/admin/adminDeleteHeatingBillDocument.ts
+++ b/src/actions/delete/admin/adminDeleteHeatingBillDocument.ts
@@ -3,6 +3,7 @@
 import database from "@/db";
 import {
   heating_bill_documents,
+  heating_invoices,
 } from "@/db/drizzle/schema";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
 import { getAuthenticatedServerUser } from "@/utils/auth/server";
@@ -18,6 +19,10 @@ export async function adminDeleteHeatingBillDocument(
   if (!user) {
     throw new Error("Nicht authentifiziert");
   }
+
+  await database
+    .delete(heating_invoices)
+    .where(and(eq(heating_invoices.heating_doc_id, docID), eq(heating_invoices.user_id, userID)));
 
   const result = await database
     .delete(heating_bill_documents)

--- a/src/actions/delete/deleteHeatingBillDocument.ts
+++ b/src/actions/delete/deleteHeatingBillDocument.ts
@@ -3,6 +3,7 @@
 import database from "@/db";
 import {
   heating_bill_documents,
+  heating_invoices,
 } from "@/db/drizzle/schema";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
 import { getAuthenticatedServerUser } from "@/utils/auth/server";
@@ -17,6 +18,10 @@ export async function deleteHeatingBillDocument(
   if (!user) {
     throw new Error("Nicht authentifiziert");
   }
+
+  await database
+    .delete(heating_invoices)
+    .where(and(eq(heating_invoices.heating_doc_id, docID), eq(heating_invoices.user_id, user.id)));
 
   const result = await database
     .delete(heating_bill_documents)

--- a/src/app/api/bved/v1/heating-statements/[id]/route.ts
+++ b/src/app/api/bved/v1/heating-statements/[id]/route.ts
@@ -779,7 +779,7 @@ async function handleUpdate(request: Request, statementId: string) {
  * 
  * Data Scoping:
  * - Statement must belong to token.user_id
- * - Cascade deletes related invoices automatically (via foreign key)
+ * - Related invoices are deleted before deleting the statement
  */
 export async function DELETE(
   request: Request,
@@ -862,8 +862,12 @@ export async function DELETE(
       );
     }
 
-    // Delete heating bill document (invoices cascade delete via foreign key)
+    // Delete related invoices first, then the heating bill document
     try {
+      await database
+        .delete(heating_invoices)
+        .where(eq(heating_invoices.heating_doc_id, statementId));
+
       const deleted = await database
         .delete(heating_bill_documents)
         .where(eq(heating_bill_documents.id, statementId))

--- a/src/app/api/heating-bill/_lib/compute.ts
+++ b/src/app/api/heating-bill/_lib/compute.ts
@@ -37,7 +37,7 @@ const HCA_DEVICE_TYPES = [
 ];
 const WARM_WATER_DEVICE_TYPES = ["WWater", "Warmwasserzähler"];
 const COLD_WATER_DEVICE_TYPES = ["Water", "Kaltwasserzähler"];
-const LOGIN_ENTRY_URL = "https://heidisystems.com/";
+const LOGIN_ENTRY_URL = "https://heidisystems.com/?tenant-login=true";
 
 function round2(v: number): number {
   return Math.round(v * 100) / 100;

--- a/src/app/api/heating-bill/_lib/mock-model.ts
+++ b/src/app/api/heating-bill/_lib/mock-model.ts
@@ -24,10 +24,10 @@ export const mockHeatingBillModel: HeatingBillPdfModel = {
     usagePeriodEnd: "31.12.2023",
     totalAmount: 1429.55,
     totalAmountFormatted: "1.429,55 €",
-    portalLink: "https://heidisystems.com/",
+    portalLink: "https://heidisystems.com/?tenant-login=true",
     userId: "1901913711",
     securityCode: "QNQH27LF1j",
-    qrCodeUrl: "https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https://heidisystems.com/",
+    qrCodeUrl: "https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https://heidisystems.com/?tenant-login=true",
   },
 
   buildingCalc: {
@@ -381,7 +381,7 @@ export const mockHeatingBillModel: HeatingBillPdfModel = {
     unitTotalCost: 0,
     unitTotalCostFormatted: "0,00 €",
 
-    qrCodeUrl: "https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https://heidisystems.com/",
+    qrCodeUrl: "https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https://heidisystems.com/?tenant-login=true",
     infoLink: "https://heidi.systems/co2",
   },
 
@@ -422,7 +422,7 @@ export const mockHeatingBillModel: HeatingBillPdfModel = {
     comparisonWarmWaterNationalKwh: 1728.53,
     comparisonWarmWaterNationalKwhFormatted: "1.729",
 
-    qrCodeUrl: "https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https://heidisystems.com/",
+    qrCodeUrl: "https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https://heidisystems.com/?tenant-login=true",
     infoLink: "https://heidi.systems/energy",
     energyAgencyLink: "https://www.deutschland-machts-effizient.de",
   },

--- a/src/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal.tsx
+++ b/src/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { green_check_circle, close_dialog } from "@/static/icons";
 
@@ -9,9 +8,10 @@ interface HeatingBillPDFPendingModalProps {
   isOpen: boolean;
 }
 
-export default function HeatingBillPDFPendingModal({ isOpen }: HeatingBillPDFPendingModalProps) {
+export default function HeatingBillPDFPendingModal({
+  isOpen,
+}: Readonly<HeatingBillPDFPendingModalProps>) {
   const [dismissed, setDismissed] = useState(false);
-  const router = useRouter();
 
   if (!isOpen || dismissed) return null;
 
@@ -51,7 +51,7 @@ export default function HeatingBillPDFPendingModal({ isOpen }: HeatingBillPDFPen
             </p>
           </div>
           <button
-            onClick={() => router.push("/dashboard")}
+            onClick={() => setDismissed(true)}
             className="px-8 py-3 cursor-pointer rounded-md bg-green text-dark_green font-medium border-none shadow-xs transition-all duration-300 hover:opacity-80"
           >
             Weiter

--- a/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminHeatObjektauswahlForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminHeatObjektauswahlForm.tsx
@@ -64,6 +64,7 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
   const { openDialog } = useDialogStore();
   const [isPathSubmited, setIsPathSubmited] = useState<boolean>(false);
   const [path, setPath] = useState<"manuell" | "ai">("manuell");
+  const isPathDialogTemporarilyDisabled = true;
 
   const methods = useForm({
     resolver: zodResolver(abrechnungszeitraumSchema),
@@ -106,7 +107,7 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
 
   const handleSubmit = useCallback(
     async (data: AbrechnungszeitraumFormValues) => {
-      if (!isPathSubmited) {
+      if (!isPathSubmited && !isPathDialogTemporarilyDisabled) {
         openDialog("heating_bill_path_create");
         return;
       }
@@ -145,6 +146,7 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
     },
     [
       isPathSubmited,
+      isPathDialogTemporarilyDisabled,
       openDialog,
       isEditMode,
       docValues?.id,

--- a/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminHeatObjektauswahlForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminHeatObjektauswahlForm.tsx
@@ -59,7 +59,8 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
   docValues?: HeatingBillDocumentType;
 }) {
   const router = useRouter();
-  const { setStartDate, setEndDate } = useHeizkostenabrechnungStore();
+  const { setStartDate, setEndDate, setHasChanges, resetHasChanges } =
+    useHeizkostenabrechnungStore();
   const isEditMode = !!docValues;
   const { openDialog } = useDialogStore();
   const [isPathSubmited, setIsPathSubmited] = useState<boolean>(false);
@@ -99,6 +100,12 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
   }, []);
 
   useEffect(() => {
+    if (isEditMode) {
+      resetHasChanges();
+    }
+  }, [isEditMode, docValues?.id, resetHasChanges]);
+
+  useEffect(() => {
     if (isPathSubmited) {
       handleSubmit(getValues());
       setIsPathSubmited(false);
@@ -119,6 +126,32 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
           consumption_dependent: String(data.consumption_dependent),
           living_space_share: String(data.living_space_share),
         };
+
+        if (isEditMode && docValues) {
+          const originalStart = docValues.start_date
+            ? new Date(docValues.start_date).getTime()
+            : null;
+          const originalEnd = docValues.end_date
+            ? new Date(docValues.end_date).getTime()
+            : null;
+          const nextStart = payload.start_date
+            ? new Date(payload.start_date).getTime()
+            : null;
+          const nextEnd = payload.end_date
+            ? new Date(payload.end_date).getTime()
+            : null;
+
+          const dateChanged = originalStart !== nextStart || originalEnd !== nextEnd;
+          const percentChanged =
+            Number(payload.consumption_dependent) !==
+            Number(docValues.consumption_dependent ?? 0) ||
+            Number(payload.living_space_share) !==
+            Number(docValues.living_space_share ?? 0);
+
+          if (dateChanged || percentChanged) {
+            setHasChanges(true);
+          }
+        }
 
         if (isEditMode) {
           await editHeatingBillDocument(docValues?.id ?? "", payload);
@@ -149,11 +182,12 @@ export default function AdminAbrechnungszeitraumHeatObjektauswahlForm({
       isPathDialogTemporarilyDisabled,
       openDialog,
       isEditMode,
-      docValues?.id,
+      docValues,
       router,
       userID,
       path,
       objekteID,
+      setHasChanges,
     ]
   );
 

--- a/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminLocalForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminLocalForm.tsx
@@ -65,6 +65,7 @@ export default function AdminAbrechnungszeitraumLocalForm({
   const { openDialog } = useDialogStore();
   const [isPathSubmited, setIsPathSubmited] = useState<boolean>(false);
   const [path, setPath] = useState<"manuell" | "ai">("manuell");
+  const isPathDialogTemporarilyDisabled = true;
 
   const methods = useForm({
     resolver: zodResolver(abrechnungszeitraumSchema),
@@ -107,7 +108,7 @@ export default function AdminAbrechnungszeitraumLocalForm({
 
   const handleSubmit = useCallback(
     async (data: AbrechnungszeitraumFormValues) => {
-      if (!isPathSubmited) {
+      if (!isPathSubmited && !isPathDialogTemporarilyDisabled) {
         openDialog("heating_bill_path_create");
         return;
       }
@@ -147,6 +148,7 @@ export default function AdminAbrechnungszeitraumLocalForm({
     },
     [
       isPathSubmited,
+      isPathDialogTemporarilyDisabled,
       openDialog,
       isEditMode,
       docValues?.id,

--- a/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/HeatObjektauswahlForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/HeatObjektauswahlForm.tsx
@@ -61,6 +61,7 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
   const { openDialog } = useDialogStore();
   const [isPathSubmited, setIsPathSubmited] = useState<boolean>(false);
   const [path, setPath] = useState<"manuell" | "ai">("manuell");
+  const isPathDialogTemporarilyDisabled = true;
 
   const methods = useForm({
     resolver: zodResolver(abrechnungszeitraumSchema),
@@ -103,7 +104,7 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
 
   const handleSubmit = useCallback(
     async (data: AbrechnungszeitraumFormValues) => {
-      if (!isPathSubmited) {
+      if (!isPathSubmited && !isPathDialogTemporarilyDisabled) {
         openDialog("heating_bill_path_create");
         return;
       }
@@ -139,7 +140,16 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
         console.error("Fehler beim Verarbeiten des Dokuments:", err);
       }
     },
-    [isPathSubmited, openDialog, isEditMode, docValues?.id, router, path, objekteID]
+    [
+      isPathSubmited,
+      isPathDialogTemporarilyDisabled,
+      openDialog,
+      isEditMode,
+      docValues?.id,
+      router,
+      path,
+      objekteID,
+    ]
   );
 
   const backLink = isEditMode

--- a/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/HeatObjektauswahlForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/HeatObjektauswahlForm.tsx
@@ -56,7 +56,8 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
   docValues?: HeatingBillDocumentType;
 }) {
   const router = useRouter();
-  const { setStartDate, setEndDate } = useHeizkostenabrechnungStore();
+  const { setStartDate, setEndDate, setHasChanges, resetHasChanges } =
+    useHeizkostenabrechnungStore();
   const isEditMode = !!docValues;
   const { openDialog } = useDialogStore();
   const [isPathSubmited, setIsPathSubmited] = useState<boolean>(false);
@@ -96,6 +97,12 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
   }, []);
 
   useEffect(() => {
+    if (isEditMode) {
+      resetHasChanges();
+    }
+  }, [isEditMode, docValues?.id, resetHasChanges]);
+
+  useEffect(() => {
     if (isPathSubmited) {
       handleSubmit(getValues());
       setIsPathSubmited(false);
@@ -116,6 +123,32 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
           consumption_dependent: String(data.consumption_dependent),
           living_space_share: String(data.living_space_share),
         };
+
+        if (isEditMode && docValues) {
+          const originalStart = docValues.start_date
+            ? new Date(docValues.start_date).getTime()
+            : null;
+          const originalEnd = docValues.end_date
+            ? new Date(docValues.end_date).getTime()
+            : null;
+          const nextStart = payload.start_date
+            ? new Date(payload.start_date).getTime()
+            : null;
+          const nextEnd = payload.end_date
+            ? new Date(payload.end_date).getTime()
+            : null;
+
+          const dateChanged = originalStart !== nextStart || originalEnd !== nextEnd;
+          const percentChanged =
+            Number(payload.consumption_dependent) !==
+            Number(docValues.consumption_dependent ?? 0) ||
+            Number(payload.living_space_share) !==
+            Number(docValues.living_space_share ?? 0);
+
+          if (dateChanged || percentChanged) {
+            setHasChanges(true);
+          }
+        }
 
         if (isEditMode) {
           await editHeatingBillDocument(docValues?.id ?? "", payload);
@@ -145,10 +178,11 @@ export default function AbrechnungszeitraumHeatObjektauswahlForm({
       isPathDialogTemporarilyDisabled,
       openDialog,
       isEditMode,
-      docValues?.id,
+      docValues,
       router,
       path,
       objekteID,
+      setHasChanges,
     ]
   );
 

--- a/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/LocalForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/LocalForm.tsx
@@ -63,6 +63,7 @@ export default function AbrechnungszeitraumLocalForm({
   const { openDialog } = useDialogStore();
   const [isPathSubmited, setIsPathSubmited] = useState<boolean>(false);
   const [path, setPath] = useState<"manuell" | "ai">("manuell");
+  const isPathDialogTemporarilyDisabled = true;
 
   const methods = useForm({
     resolver: zodResolver(abrechnungszeitraumSchema),
@@ -105,7 +106,7 @@ export default function AbrechnungszeitraumLocalForm({
 
   const handleSubmit = useCallback(
     async (data: AbrechnungszeitraumFormValues) => {
-      if (!isPathSubmited) {
+      if (!isPathSubmited && !isPathDialogTemporarilyDisabled) {
         openDialog("heating_bill_path_create");
         return;
       }
@@ -144,6 +145,7 @@ export default function AbrechnungszeitraumLocalForm({
     },
     [
       isPathSubmited,
+      isPathDialogTemporarilyDisabled,
       openDialog,
       isEditMode,
       docValues?.id,

--- a/src/components/Admin/Forms/DocPreparing/Common/AdminSaveCostButton.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Common/AdminSaveCostButton.tsx
@@ -22,6 +22,7 @@ export default function AdminSaveCostButton({
   objektId,
   localId,
   userId,
+  isEditMode = false,
 }: {
   initialDocumentGroups: DocCostCategoryType[];
   documentType: "heizkostenabrechnung" | "betriebskostenabrechnung";
@@ -29,12 +30,14 @@ export default function AdminSaveCostButton({
   objektId: string;
   localId?: string;
   userId?: string;
+  isEditMode?: boolean;
 }) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { documentGroups: betriebskostenGroups } =
     useBetriebskostenabrechnungStore();
-  const { documentGroups: heizkostenGroups } = useHeizkostenabrechnungStore();
+  const { documentGroups: heizkostenGroups, hasChanges } =
+    useHeizkostenabrechnungStore();
 
   const documentGroups =
     documentType === "betriebskostenabrechnung"
@@ -68,6 +71,25 @@ export default function AdminSaveCostButton({
         return initial && initial.allocation_key !== current.allocation_key;
       });
 
+      let redirectUrl = "";
+      if (documentType === "betriebskostenabrechnung") {
+        redirectUrl = `${ROUTE_ADMIN}/${userId}${ROUTE_BETRIEBSKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+      } else if (localId) {
+        redirectUrl = `${ROUTE_ADMIN}/${userId}${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/${objektId}/${localId}/${operatingDocId}/results`;
+      } else {
+        redirectUrl = `${ROUTE_ADMIN}/${userId}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+      }
+
+      const anythingChanged = hasChanges || changedItems.length > 0;
+      if (
+        documentType === "heizkostenabrechnung" &&
+        isEditMode &&
+        !anythingChanged
+      ) {
+        router.push(redirectUrl);
+        return;
+      }
+
       await Promise.all(
         changedItems
           .filter(
@@ -87,16 +109,11 @@ export default function AdminSaveCostButton({
           )
       );
 
-      let redirectUrl = "";
       if (documentType === "betriebskostenabrechnung") {
         await submitBuildingDocument(operatingDocId);
-        redirectUrl = `${ROUTE_ADMIN}/${userId}${ROUTE_BETRIEBSKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
       } else {
         await submitHeatLocalDocument(operatingDocId);
-        if (localId) {
-          redirectUrl = `${ROUTE_ADMIN}/${userId}${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/${objektId}/${localId}/${operatingDocId}/results`;
-        } else {
-          redirectUrl = `${ROUTE_ADMIN}/${userId}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+        if (!localId) {
           await runBatchGeneration(objektId, operatingDocId);
         }
       }

--- a/src/components/Admin/Forms/DocPreparing/Common/SaveCostButton.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Common/SaveCostButton.tsx
@@ -20,18 +20,21 @@ export default function SaveCostButton({
   operatingDocId,
   objektId,
   localId,
+  isEditMode = false,
 }: {
   initialDocumentGroups: DocCostCategoryType[];
   documentType: "heizkostenabrechnung" | "betriebskostenabrechnung";
   operatingDocId: string;
   objektId: string;
   localId?: string;
+  isEditMode?: boolean;
 }) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { documentGroups: betriebskostenGroups } =
     useBetriebskostenabrechnungStore();
-  const { documentGroups: heizkostenGroups } = useHeizkostenabrechnungStore();
+  const { documentGroups: heizkostenGroups, hasChanges } =
+    useHeizkostenabrechnungStore();
 
   const documentGroups =
     documentType === "betriebskostenabrechnung"
@@ -65,6 +68,25 @@ export default function SaveCostButton({
         return initial && initial.allocation_key !== current.allocation_key;
       });
 
+      let redirectUrl = "";
+      if (documentType === "betriebskostenabrechnung") {
+        redirectUrl = `${ROUTE_BETRIEBSKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+      } else if (localId) {
+        redirectUrl = `${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/${objektId}/${localId}/${operatingDocId}/results`;
+      } else {
+        redirectUrl = `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+      }
+
+      const anythingChanged = hasChanges || changedItems.length > 0;
+      if (
+        documentType === "heizkostenabrechnung" &&
+        isEditMode &&
+        !anythingChanged
+      ) {
+        router.push(redirectUrl);
+        return;
+      }
+
       await Promise.all(
         changedItems
           .filter(
@@ -84,16 +106,11 @@ export default function SaveCostButton({
           )
       );
 
-      let redirectUrl = "";
       if (documentType === "betriebskostenabrechnung") {
         await submitBuildingDocument(operatingDocId);
-        redirectUrl = `${ROUTE_BETRIEBSKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
       } else {
         await submitHeatLocalDocument(operatingDocId);
-        if (localId) {
-          redirectUrl = `${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/${objektId}/${localId}/${operatingDocId}/results`;
-        } else {
-          redirectUrl = `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${objektId}/${operatingDocId}/results`;
+        if (!localId) {
           await runBatchGeneration(objektId, operatingDocId);
         }
       }

--- a/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/Admin/AdminHeatObjektauswahlForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/Admin/AdminHeatObjektauswahlForm.tsx
@@ -58,6 +58,7 @@ export default function AdminUmlageschlüsselHeatObjektauswahlForm({
             initialDocumentGroups={initialDocumentGroups}
             documentType="heizkostenabrechnung"
             operatingDocId={docId}
+            isEditMode={isEditMode}
           />
         </div>
       </div>

--- a/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/Admin/AdminLocalForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/Admin/AdminLocalForm.tsx
@@ -61,6 +61,7 @@ export default function AdminUmlageschlüsselLocalForm({
             documentType="heizkostenabrechnung"
             operatingDocId={docId}
             localId={localId}
+            isEditMode={isEditMode}
           />
         </div>
       </div>

--- a/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/HeatObjektauswahlForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/HeatObjektauswahlForm.tsx
@@ -55,6 +55,7 @@ export default function UmlageschlüsselHeatObjektauswahlForm({
             initialDocumentGroups={initialDocumentGroups}
             documentType="heizkostenabrechnung"
             operatingDocId={docId}
+            isEditMode={isEditMode}
           />
         </div>
       </div>

--- a/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/LocalForm.tsx
+++ b/src/components/Admin/Forms/DocPreparing/Umlageschlüssel/LocalForm.tsx
@@ -58,6 +58,7 @@ export default function UmlageschlüsselLocalForm({
             documentType="heizkostenabrechnung"
             operatingDocId={docId}
             localId={localId}
+            isEditMode={isEditMode}
           />
         </div>
       </div>

--- a/src/components/Admin/ObjekteItem/Admin/AdminHeatObjekteItemDocWithHistory.tsx
+++ b/src/components/Admin/ObjekteItem/Admin/AdminHeatObjekteItemDocWithHistory.tsx
@@ -76,11 +76,9 @@ export default function AdminHeatObjekteItemDocWithHistory({
       >
         {relatedOpenedDocuments?.map((doc) => {
           const isSubmitted = doc.submited;
-          const href = isSubmitted
-            ? `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${item.id}/${doc.id}/results`
-            : doc.local_id
-              ? `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/weitermachen/${doc.id}/abrechnungszeitraum`
-              : `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`;
+          const href = doc.local_id
+            ? `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/weitermachen/${doc.id}/abrechnungszeitraum`
+            : `${ROUTE_ADMIN}/${user_id}${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`;
 
           return (
             <div className="flex items-center justify-between" key={doc.id}>

--- a/src/components/Admin/ObjekteItem/ObjekteItemDocWithHistory.tsx
+++ b/src/components/Admin/ObjekteItem/ObjekteItemDocWithHistory.tsx
@@ -74,11 +74,9 @@ export default function ObjekteItemDocWithHistory({
       >
         {relatedOpenedDocuments?.map((doc) => {
           const isSubmitted = doc.submited;
-          const href = isSubmitted
-            ? `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/${item.id}/${doc.id}/results`
-            : doc.local_id
-              ? `${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/weitermachen/${doc.id}/abrechnungszeitraum`
-              : `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`;
+          const href = doc.local_id
+            ? `${ROUTE_HEIZKOSTENABRECHNUNG}/localauswahl/weitermachen/${doc.id}/abrechnungszeitraum`
+            : `${ROUTE_HEIZKOSTENABRECHNUNG}/objektauswahl/weitermachen/${doc.id}/abrechnungszeitraum`;
 
           return (
             <div className="flex items-center justify-between" key={doc.id}>

--- a/src/components/Basic/Dialog/HeatingBillPathDialog.tsx
+++ b/src/components/Basic/Dialog/HeatingBillPathDialog.tsx
@@ -15,196 +15,198 @@ export default function HeatingBillPathDialog({
   path,
   setPath,
   setIsPathSubmited,
-}: {
+}: Readonly<{
   path: "manuell" | "ai";
   setPath: (path: "manuell" | "ai") => void;
   setIsPathSubmited: (isPathSubmited: boolean) => void;
-}) {
+}>) {
   const { openDialogByType, closeDialog } = useDialogStore();
   const isOpen = openDialogByType.heating_bill_path_create;
+  const isTemporarilyDisabled = true;
 
   const actionBtn =
     "h-12 px-8 max-xl:px-3.5 max-xl:text-sm max-medium:w-full rounded-lg flex items-center justify-center font-medium";
 
-  if (isOpen)
-    return (
-      <DialogBase size={780} dialogName="heating_bill_path_create">
-        <div className="py-6 max-medium:py-3">
-          <h2 className="text-center mb-4 max-medium:mb-2 font-bold text-admin_dark_text text-lg max-medium:text-base">
-            Neues Gebäude anlegen
-          </h2>
-          <p className="text-center text-admin_dark_text text-sm max-medium:text-xs">
-            Mit einem neuen KI-gestützten Tool lassen sich komplette Objekte in nur wenigen Klicks digital übertragen - inklusive der vollständigen Mieterstrukturen, Einheiten- und Wohnungszuschnitte. Apartment- und Nutzungseigenschaften werden dabei automatisch erkannt, intelligent zugeordnet und strukturiert angelegt.
-          </p>
-        </div>
-        <div className="grid grid-cols-2 max-medium:grid-cols-1 gap-6 max-medium:gap-4">
-          <div>
-            <input
-              className="sr-only peer"
-              type="radio"
-              name="heating_bill_type"
-              id="objektauswahl"
-              checked={path === "manuell"}
-              onChange={() => setPath("manuell")}
-            />
-            <label
-              htmlFor="objektauswahl"
-              className="block px-6 max-medium:px-4 pb-6 max-medium:pb-4 pt-11 max-medium:pt-6 rounded-xl border-[3px] border-transparent bg-white shadow-sm cursor-pointer transition-all duration-300 peer-checked:border-[3px] peer-checked:border-ai-blue space-y-2 relative peer-checked:[&_.cornerCheck]:block"
-            >
-              <div className="flex items-center justify-center flex-col gap-4 font-bold text-sm text-admin_dark_text">
-                <Image
-                  width={0}
-                  height={0}
-                  sizes="100vw"
-                  loading="lazy"
-                  className="max-w-[36px] max-h-[36px]"
-                  src={manuell}
-                  alt="manuell"
-                />
-                Manuelles anlegen
-              </div>
-              <ul className="space-y-2">
-                <li className="flex items-start gap-2 text-sm text-admin_dark_text">
-                  <Image
-                    width={0}
-                    height={0}
-                    sizes="100vw"
-                    loading="lazy"
-                    className="max-w-[24px] max-h-[24px]"
-                    src={green_check_single}
-                    alt="green_check_single"
-                  />
-                  Mieterlisten integrierbar
-                </li>
-                <li className="flex items-start gap-2 text-sm text-admin_dark_text">
-                  <Image
-                    width={0}
-                    height={0}
-                    sizes="100vw"
-                    loading="lazy"
-                    className="max-w-[24px] max-h-[24px]"
-                    src={green_check_single}
-                    alt="green_check_single"
-                  />
-                  Apartmentstruktur
-                </li>
-                <li className="flex items-start gap-2 text-sm text-admin_dark_text">
-                  <Image
-                    width={0}
-                    height={0}
-                    sizes="100vw"
-                    loading="lazy"
-                    className="max-w-[24px] max-h-[24px]"
-                    src={green_check_single}
-                    alt="green_check_single"
-                  />
-                  Übertragung von Objekt- und Apartment-strukturen
-                </li>
-              </ul>
+  if (!isOpen || isTemporarilyDisabled) return null;
+
+  return (
+    <DialogBase size={780} dialogName="heating_bill_path_create">
+      <div className="py-6 max-medium:py-3">
+        <h2 className="text-center mb-4 max-medium:mb-2 font-bold text-admin_dark_text text-lg max-medium:text-base">
+          Neues Gebäude anlegen
+        </h2>
+        <p className="text-center text-admin_dark_text text-sm max-medium:text-xs">
+          Mit einem neuen KI-gestützten Tool lassen sich komplette Objekte in nur wenigen Klicks digital übertragen - inklusive der vollständigen Mieterstrukturen, Einheiten- und Wohnungszuschnitte. Apartment- und Nutzungseigenschaften werden dabei automatisch erkannt, intelligent zugeordnet und strukturiert angelegt.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 max-medium:grid-cols-1 gap-6 max-medium:gap-4">
+        <div>
+          <input
+            className="sr-only peer"
+            type="radio"
+            name="heating_bill_type"
+            id="objektauswahl"
+            checked={path === "manuell"}
+            onChange={() => setPath("manuell")}
+          />
+          <label
+            htmlFor="objektauswahl"
+            className="block px-6 max-medium:px-4 pb-6 max-medium:pb-4 pt-11 max-medium:pt-6 rounded-xl border-[3px] border-transparent bg-white shadow-sm cursor-pointer transition-all duration-300 peer-checked:border-[3px] peer-checked:border-ai-blue space-y-2 relative peer-checked:[&_.cornerCheck]:block"
+          >
+            <div className="flex items-center justify-center flex-col gap-4 font-bold text-sm text-admin_dark_text">
               <Image
                 width={0}
                 height={0}
                 sizes="100vw"
                 loading="lazy"
-                className="max-w-[20px] max-h-[22px] absolute top-[-1px] right-[-1px] cornerCheck hidden"
-                src={blue_corner_check}
-                alt="blue_corner_check"
+                className="max-w-[36px] max-h-[36px]"
+                src={manuell}
+                alt="manuell"
               />
-            </label>
-          </div>
-          <div>
-            <input
-              className="sr-only peer"
-              type="radio"
-              name="heating_bill_type"
-              id="ai"
-              checked={path === "ai"}
-              onChange={() => setPath("ai")}
-            />
-            <label
-              htmlFor="ai"
-              className="block px-6 max-medium:px-4 pb-6 max-medium:pb-4 pt-11 max-medium:pt-6 rounded-xl border-[3px] border-transparent bg-white shadow-sm cursor-pointer transition-all duration-100 peer-checked:border-[3px] peer-checked:border-ai-blue space-y-2 relative peer-checked:[&_.cornerCheck]:block"
-            >
-              <div className="flex items-center justify-center flex-col gap-4 font-bold text-sm text-admin_dark_text">
+              Manuelles anlegen
+            </div>
+            <ul className="space-y-2">
+              <li className="flex items-start gap-2 text-sm text-admin_dark_text">
                 <Image
                   width={0}
                   height={0}
                   sizes="100vw"
                   loading="lazy"
-                  className="max-w-[50px] max-h-[50px]"
+                  className="max-w-[24px] max-h-[24px]"
+                  src={green_check_single}
+                  alt="green_check_single"
+                />
+                Mieterlisten integrierbar
+              </li>
+              <li className="flex items-start gap-2 text-sm text-admin_dark_text">
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-[24px] max-h-[24px]"
+                  src={green_check_single}
+                  alt="green_check_single"
+                />
+                Apartmentstruktur
+              </li>
+              <li className="flex items-start gap-2 text-sm text-admin_dark_text">
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-[24px] max-h-[24px]"
+                  src={green_check_single}
+                  alt="green_check_single"
+                />
+                Übertragung von Objekt- und Apartment-strukturen
+              </li>
+            </ul>
+            <Image
+              width={0}
+              height={0}
+              sizes="100vw"
+              loading="lazy"
+              className="max-w-[20px] max-h-[22px] absolute top-[-1px] right-[-1px] cornerCheck hidden"
+              src={blue_corner_check}
+              alt="blue_corner_check"
+            />
+          </label>
+        </div>
+        <div>
+          <input
+            className="sr-only peer"
+            type="radio"
+            name="heating_bill_type"
+            id="ai"
+            checked={path === "ai"}
+            onChange={() => setPath("ai")}
+          />
+          <label
+            htmlFor="ai"
+            className="block px-6 max-medium:px-4 pb-6 max-medium:pb-4 pt-11 max-medium:pt-6 rounded-xl border-[3px] border-transparent bg-white shadow-sm cursor-pointer transition-all duration-100 peer-checked:border-[3px] peer-checked:border-ai-blue space-y-2 relative peer-checked:[&_.cornerCheck]:block"
+          >
+            <div className="flex items-center justify-center flex-col gap-4 font-bold text-sm text-admin_dark_text">
+              <Image
+                width={0}
+                height={0}
+                sizes="100vw"
+                loading="lazy"
+                className="max-w-[50px] max-h-[50px]"
+                src={ai_starts}
+                alt="ai_starts"
+              />
+              Automatisch anlegen
+            </div>
+            <ul className="space-y-2">
+              <li className="flex items-start gap-2 text-sm text-admin_dark_text">
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-[24px] max-h-[24px]"
                   src={ai_starts}
                   alt="ai_starts"
                 />
-                Automatisch anlegen
-              </div>
-              <ul className="space-y-2">
-                <li className="flex items-start gap-2 text-sm text-admin_dark_text">
-                  <Image
-                    width={0}
-                    height={0}
-                    sizes="100vw"
-                    loading="lazy"
-                    className="max-w-[24px] max-h-[24px]"
-                    src={ai_starts}
-                    alt="ai_starts"
-                  />
-                  Automatische Mieterstruktur
-                </li>
-                <li className="flex items-start gap-2 text-sm text-admin_dark_text">
-                  <Image
-                    width={0}
-                    height={0}
-                    sizes="100vw"
-                    loading="lazy"
-                    className="max-w-[24px] max-h-[24px]"
-                    src={ai_starts}
-                    alt="ai_starts"
-                  />
-                  Objekt und Apartments werden automatisch angelegt
-                </li>
-                <li className="flex items-start gap-2 text-sm text-admin_dark_text">
-                  <Image
-                    width={0}
-                    height={0}
-                    sizes="100vw"
-                    loading="lazy"
-                    className="max-w-[24px] max-h-[24px]"
-                    src={ai_starts}
-                    alt="ai_starts"
-                  />
-                  Energiemix wird übertragen
-                </li>
-              </ul>
-              <Image
-                width={0}
-                height={0}
-                sizes="100vw"
-                loading="lazy"
-                className="max-w-[20px] max-h-[22px] absolute top-[-1px] right-[-1px] cornerCheck hidden"
-                src={blue_corner_check}
-                alt="blue_corner_check"
-              />
-            </label>
-          </div>
+                Automatische Mieterstruktur
+              </li>
+              <li className="flex items-start gap-2 text-sm text-admin_dark_text">
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-[24px] max-h-[24px]"
+                  src={ai_starts}
+                  alt="ai_starts"
+                />
+                Objekt und Apartments werden automatisch angelegt
+              </li>
+              <li className="flex items-start gap-2 text-sm text-admin_dark_text">
+                <Image
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  loading="lazy"
+                  className="max-w-[24px] max-h-[24px]"
+                  src={ai_starts}
+                  alt="ai_starts"
+                />
+                Energiemix wird übertragen
+              </li>
+            </ul>
+            <Image
+              width={0}
+              height={0}
+              sizes="100vw"
+              loading="lazy"
+              className="max-w-[20px] max-h-[22px] absolute top-[-1px] right-[-1px] cornerCheck hidden"
+              src={blue_corner_check}
+              alt="blue_corner_check"
+            />
+          </label>
         </div>
-        <div className="flex items-center justify-between max-medium:flex-col max-medium:gap-3">
-          <button
-            onClick={() => closeDialog("heating_bill_path_create")}
-            className={`${actionBtn} border border-admin_dark_text/50 text-admin_dark_text bg-[#e0e0e0] hover:bg-[#d0d0d0] transition-colors duration-300 max-medium:order-2`}
-          >
-            Zurück
-          </button>
+      </div>
+      <div className="flex items-center justify-between max-medium:flex-col max-medium:gap-3">
+        <button
+          onClick={() => closeDialog("heating_bill_path_create")}
+          className={`${actionBtn} border border-admin_dark_text/50 text-admin_dark_text bg-[#e0e0e0] hover:bg-[#d0d0d0] transition-colors duration-300 max-medium:order-2`}
+        >
+          Zurück
+        </button>
 
-          <Button
-            onClick={() => {
-              setIsPathSubmited(true);
-              closeDialog("heating_bill_path_create");
-            }}
-            className={`${actionBtn} bg-ai-blue hover:bg-ai-blue/80 max-medium:order-1`}
-          >
-            Loslegen
-          </Button>
-        </div>
-      </DialogBase>
-    );
+        <Button
+          onClick={() => {
+            setIsPathSubmited(true);
+            closeDialog("heating_bill_path_create");
+          }}
+          className={`${actionBtn} bg-ai-blue hover:bg-ai-blue/80 max-medium:order-1`}
+        >
+          Loslegen
+        </Button>
+      </div>
+    </DialogBase>
+  );
 }

--- a/src/store/useHeizkostenabrechnungStore.tsx
+++ b/src/store/useHeizkostenabrechnungStore.tsx
@@ -10,8 +10,11 @@ export type HeizkostenabrechnungCostType = Partial<DocCostCategoryType> & {
 export type HeizkostenabrechnungStoreType = {
   start_date: Date | null;
   end_date: Date | null;
+  hasChanges: boolean;
   activeCostType: HeizkostenabrechnungCostType["type"] | null;
   documentGroups: HeizkostenabrechnungCostType[];
+  setHasChanges: (value: boolean) => void;
+  resetHasChanges: () => void;
   setDocumentGroups: (groups: HeizkostenabrechnungCostType[]) => void;
   setStartDate: (date: Date) => void;
   setEndDate: (date: Date) => void;
@@ -55,12 +58,21 @@ export const useHeizkostenabrechnungStore =
   create<HeizkostenabrechnungStoreType>((set, get) => ({
     start_date: new Date(new Date().getFullYear(), 0, 1),
     end_date: null,
+    hasChanges: false,
     activeCostType: null,
     documentGroups: [],
     objektID: undefined,
     operatingDocID: undefined,
     localID: null,
     purposeOptions: [],
+    setHasChanges: (value) =>
+      set(() => ({
+        hasChanges: value,
+      })),
+    resetHasChanges: () =>
+      set(() => ({
+        hasChanges: false,
+      })),
     setDocumentGroups: (groups) =>
       set({
         documentGroups: groups,
@@ -103,10 +115,14 @@ export const useHeizkostenabrechnungStore =
       set((state) => {
         if (state.documentGroups.some((g) => g.type === group.type))
           return state;
-        return { documentGroups: [...state.documentGroups, group] };
+        return {
+          documentGroups: [...state.documentGroups, group],
+          hasChanges: true,
+        };
       }),
     updateDocumentGroup: (key, newItem) =>
       set((state) => ({
+        hasChanges: true,
         documentGroups: state.documentGroups.map((group) =>
           group.type === key
             ? { ...group, data: [...group.data, newItem] }
@@ -115,6 +131,7 @@ export const useHeizkostenabrechnungStore =
       })),
     editDocumentGroup: (key, itemID, updatedItem) =>
       set((state) => ({
+        hasChanges: true,
         documentGroups: state.documentGroups.map((group) =>
           group.type === key
             ? {
@@ -149,12 +166,14 @@ export const useHeizkostenabrechnungStore =
       })),
     removeDocumentGroup: (key) =>
       set((state) => ({
+        hasChanges: true,
         documentGroups: state.documentGroups.filter(
           (group) => group.type !== key
         ),
       })),
     removeInvoiceFromGroup: (itemID) =>
       set((state) => ({
+        hasChanges: true,
         documentGroups: state.documentGroups.map((group) => ({
           ...group,
           data: group.data.filter((item) => String(item.id) !== String(itemID)),


### PR DESCRIPTION
# PR Description: Skip Heating Bill Generation When No Changes Detected

Team,
Moving forward, all PRs must include clear comments and a proper description outlining:

- What was changed
- Why it was changed
- Any impact on CI, deployments, or infrastructure
- Any required follow-up actions

Right now too much intent has to be inferred from commits and deployments, which slows review and increases the risk of misalignment.
Clear documentation in the PR will make reviews faster, reduce back and forth, and help us keep main and production stable.
Thank you.

## What Was Changed

- Added cross-step change tracking to `useHeizkostenabrechnungStore` with:
  - `hasChanges: boolean`
  - `setHasChanges(value: boolean)`
  - `resetHasChanges()`
- Marked heating-bill flow as changed when invoice/cost-type mutations happen:
  - `addDocumentGroup`
  - `updateDocumentGroup`
  - `editDocumentGroup`
  - `removeDocumentGroup`
  - `removeInvoiceFromGroup`
- Added edit-flow change detection in both billing-period forms:
  - `src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminHeatObjektauswahlForm.tsx`
  - `src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/HeatObjektauswahlForm.tsx`
  - Compares submitted billing-period/percentage values against original `docValues` and sets `hasChanges` when different.
  - Resets `hasChanges` when entering edit mode.
- Updated final save buttons for heating bills to skip generation when unchanged in edit mode:
  - `src/components/Admin/Forms/DocPreparing/Common/AdminSaveCostButton.tsx`
  - `src/components/Admin/Forms/DocPreparing/Common/SaveCostButton.tsx`
  - New behavior:
    - Build result redirect URL first
    - Compute `anythingChanged = hasChanges || changedItems.length > 0`
    - If `isEditMode` + heating bill + unchanged: redirect directly to results and return
    - Otherwise continue existing flow (save changed allocation keys, submit, run batch generation when building-level)
- Passed `isEditMode` through heating `Umlageschluessel` forms so save buttons can apply unchanged-edit logic:
  - `.../Umlageschlüssel/Admin/AdminHeatObjektauswahlForm.tsx`
  - `.../Umlageschlüssel/HeatObjektauswahlForm.tsx`
  - `.../Umlageschlüssel/Admin/AdminLocalForm.tsx`
  - `.../Umlageschlüssel/LocalForm.tsx`
- Updated heating bill pending modal action behavior to stay on the current results view instead of redirecting to dashboard:
  - `src/components/Admin/Docs/HeatingBillPDFPendingModal/HeatingBillPDFPendingModal.tsx`
  - Changed "Weiter" button handler to close/dismiss the modal (same as the `X` close button).
  - Removed dashboard navigation side effect from modal confirmation action.
- Updated heating-bill history list navigation so generated (submitted) documents now open the edit flow, matching pending documents, in both admin and non-admin views:
  - `src/components/Admin/ObjekteItem/Admin/AdminHeatObjekteItemDocWithHistory.tsx`
  - `src/components/Admin/ObjekteItem/ObjekteItemDocWithHistory.tsx`
  - Removed submitted-only redirect to `/results` from these list entries.
  - Preserved `localauswahl` vs `objektauswahl` routing based on `doc.local_id` in both views.
- Fixed heating bill deletion FK violation by deleting related `heating_invoices` rows before deleting `heating_bill_documents` in all affected delete paths:
  - `src/actions/delete/deleteHeatingBillDocument.ts`
  - `src/actions/delete/admin/adminDeleteHeatingBillDocument.ts`
  - `src/app/api/bved/v1/heating-statements/[id]/route.ts`
- Updated BVED DELETE route comments to match actual behavior (manual child cleanup before parent delete, not FK cascade).
- Temporarily disabled the heating bill path selection modal from rendering:
  - `src/components/Basic/Dialog/HeatingBillPathDialog.tsx`
  - Added temporary guard (`isTemporarilyDisabled = true`) so dialog returns `null` even if opened.
  - Updated component props typing to `Readonly<...>` to satisfy linting.
- Added temporary submit fallback so "Weiter" continues without modal confirmation while path dialog is disabled:
  - `src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/HeatObjektauswahlForm.tsx`
  - `src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminHeatObjektauswahlForm.tsx`
  - `src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/LocalForm.tsx`
  - `src/components/Admin/Forms/DocPreparing/Abrechnungszeitraum/Admin/AdminLocalForm.tsx`
  - Submit guard now bypasses `openDialog("heating_bill_path_create")` when `isPathDialogTemporarilyDisabled` is set.
- Updated heating-bill PDF QR-code destination to open tenant login popup on homepage:
  - `src/app/api/heating-bill/_lib/compute.ts`
  - Changed `LOGIN_ENTRY_URL` from `https://heidisystems.com/` to `https://heidisystems.com/?tenant-login=true`.
  - This propagates to PDF QR codes via existing `portalLink` usage.
- Updated mock heating-bill QR links to match production tenant-login redirect behavior:
  - `src/app/api/heating-bill/_lib/mock-model.ts`
  - Updated `cover.portalLink` and all hardcoded QR URLs (`cover`, `co2`, `energySummary`) to use `?tenant-login=true`.

## Why It Was Changed

- Users in the heating-bill edit flow could click through without changing any inputs and still trigger full PDF regeneration.
- That caused unnecessary background generation work, delayed UX, and avoidable storage/document churn.
- This change ensures unchanged edits redirect directly to the results page without generating a new heating bill.
- In the pending modal, users now remain in-context on the current results view when confirming, avoiding unintended navigation to dashboard.
- Generated entries in the heating-bill history list previously opened the results page while pending entries opened the edit flow, creating inconsistent navigation behavior.
- This change aligns both generated and pending entries to open the edit flow in admin and non-admin views for a consistent continue/edit experience.
- Deleting a heating bill with linked invoices failed with Postgres error `23503` (`heating_invoices_heating_doc_id_fkey`) because child rows still referenced the parent document.
- This change guarantees deterministic delete behavior by explicitly removing linked invoices first across user, admin, and BVED deletion flows.
- Temporarily suppressing the path selection modal caused `Weiter` to stall in billing-period forms because submission depended on `isPathSubmited` being set by modal confirmation.
- The temporary submit bypass preserves existing navigation flow until the path modal is re-enabled.
- QR codes in generated heating-bill PDFs previously opened only the homepage; this change routes users directly into the tenant-login entry flow by opening homepage with tenant-login popup enabled.

## Impact on CI, Deployments, or Infrastructure

- CI: No pipeline/configuration changes required.
- Deployments: Standard frontend deployment only.
- Infrastructure/services:
  - No schema changes
  - No new services
  - No endpoint contract changes
  - Reduced load on heating-bill batch generation path for unchanged edit sessions
  - Prevents 500 responses during heating bill delete operations when invoices exist
  - Heating-bill PDF QR scans now deep-link to tenant-login entry (`/?tenant-login=true`) for faster tenant sign-in
  - No migration required (application-level delete ordering fix)

## Required Follow-Up Actions

- QA (manual):
  - Edit flow with no changes across all steps -> should redirect to results without generation.
  - Edit flow with any change (period values, invoices/cost types, allocation keys) -> should continue to generate as before.
  - Validate both admin and non-admin heating-bill flows.
  - From heating-bill history list entries (admin + non-admin), clicking generated/submitted docs should open `.../weitermachen/:doc_id/abrechnungszeitraum` (not `/results`), same as pending docs.
  - With path dialog temporarily disabled, `Weiter` should continue correctly in all four billing-period variants (admin/non-admin, object/local).
  - Delete heating bill with linked invoices (admin + non-admin) -> should succeed without FK errors.
  - DELETE `/api/bved/v1/heating-statements/:id` for a statement with invoices -> should return success and remove statement + invoices.
  - Scan heating-bill PDF QR code (cover/CO2/energy-summary pages) -> should open homepage and auto-open tenant login popup (`tenant-login=true` flow).
- Monitor post-release:
  - Confirm expected reduction in no-op generation runs.
  - Confirm no regression in result-page navigation paths.
  - Monitor logs for disappearance of `heating_invoices_heating_doc_id_fkey` delete errors.
  - After re-enabling path modal, remove temporary disable/bypass flags and verify modal-confirmation flow works again.