### PR TITLE
Refactor: Replace supabaseServer with supabaseServiceRole for documen…

### DIFF
--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/preview/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/preview/page.tsx
@@ -5,12 +5,12 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import PdfViewer from "@/components/Admin/Docs/Render/PdfViewer";
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import { supabaseServer } from "@/utils/supabase/server";
+import { supabaseServiceRole } from "@/utils/supabase/serviceRole";
 
 export default async function ResultLocalPreview({
   params,
   searchParams,
-}: {
+}: Readonly<{
   params: Promise<{
     objekt_id: string;
     doc_id: string;
@@ -18,7 +18,7 @@ export default async function ResultLocalPreview({
     user_id: string;
   }>;
   searchParams: Promise<{ documentId?: string }>;
-}) {
+}>) {
   const { objekt_id, doc_id, local_id, user_id } = await params;
   const { documentId } = await searchParams;
 
@@ -27,10 +27,16 @@ export default async function ResultLocalPreview({
   if (documentId) {
     const doc = await getDocumentById(documentId);
     if (doc) {
-      const supabase = await supabaseServer();
-      const { data } = await supabase.storage
+      const supabase = supabaseServiceRole();
+      const { data, error } = await supabase.storage
         .from("documents")
         .createSignedUrl(doc.document_url, 3600);
+      if (error) {
+        console.error("[Preview] createSignedUrl failed:", error.message, {
+          documentId,
+          path: doc.document_url,
+        });
+      }
       pdfUrl = data?.signedUrl ?? null;
     }
   }

--- a/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/[local_id]/preview/page.tsx
+++ b/src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/[local_id]/preview/page.tsx
@@ -5,12 +5,12 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import PdfViewer from "@/components/Admin/Docs/Render/PdfViewer";
 import { ROUTE_ADMIN, ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import { supabaseServer } from "@/utils/supabase/server";
+import { supabaseServiceRole } from "@/utils/supabase/serviceRole";
 
 export default async function ResultLocalPreview({
   params,
   searchParams,
-}: {
+}: Readonly<{
   params: Promise<{
     objekt_id: string;
     doc_id: string;
@@ -18,7 +18,7 @@ export default async function ResultLocalPreview({
     user_id: string;
   }>;
   searchParams: Promise<{ documentId?: string }>;
-}) {
+}>) {
   const { objekt_id, doc_id, user_id } = await params;
   const { documentId } = await searchParams;
 
@@ -27,10 +27,16 @@ export default async function ResultLocalPreview({
   if (documentId) {
     const doc = await getDocumentById(documentId);
     if (doc) {
-      const supabase = await supabaseServer();
-      const { data } = await supabase.storage
+      const supabase = supabaseServiceRole();
+      const { data, error } = await supabase.storage
         .from("documents")
         .createSignedUrl(doc.document_url, 3600);
+      if (error) {
+        console.error("[Preview] createSignedUrl failed:", error.message, {
+          documentId,
+          path: doc.document_url,
+        });
+      }
       pdfUrl = data?.signedUrl ?? null;
     }
   }

--- a/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/preview/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/preview/page.tsx
@@ -5,15 +5,15 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import PdfViewer from "@/components/Admin/Docs/Render/PdfViewer";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import { supabaseServer } from "@/utils/supabase/server";
+import { supabaseServiceRole } from "@/utils/supabase/serviceRole";
 
 export default async function ResultLocalPreview({
   params,
   searchParams,
-}: {
+}: Readonly<{
   params: Promise<{ objekt_id: string; doc_id: string; local_id: string }>;
   searchParams: Promise<{ documentId?: string }>;
-}) {
+}>) {
   const { objekt_id, doc_id, local_id } = await params;
   const { documentId } = await searchParams;
 
@@ -22,10 +22,16 @@ export default async function ResultLocalPreview({
   if (documentId) {
     const doc = await getDocumentById(documentId);
     if (doc) {
-      const supabase = await supabaseServer();
-      const { data } = await supabase.storage
+      const supabase = supabaseServiceRole();
+      const { data, error } = await supabase.storage
         .from("documents")
         .createSignedUrl(doc.document_url, 3600);
+      if (error) {
+        console.error("[Preview] createSignedUrl failed:", error.message, {
+          documentId,
+          path: doc.document_url,
+        });
+      }
       pdfUrl = data?.signedUrl ?? null;
     }
   }

--- a/src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/[local_id]/preview/page.tsx
+++ b/src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/[local_id]/preview/page.tsx
@@ -5,15 +5,15 @@ import Breadcrumb from "@/components/Admin/Breadcrumb/Breadcrumb";
 import ContentWrapper from "@/components/Admin/ContentWrapper/ContentWrapper";
 import PdfViewer from "@/components/Admin/Docs/Render/PdfViewer";
 import { ROUTE_HEIZKOSTENABRECHNUNG } from "@/routes/routes";
-import { supabaseServer } from "@/utils/supabase/server";
+import { supabaseServiceRole } from "@/utils/supabase/serviceRole";
 
 export default async function ResultLocalPreview({
   params,
   searchParams,
-}: {
+}: Readonly<{
   params: Promise<{ objekt_id: string; doc_id: string; local_id: string }>;
   searchParams: Promise<{ documentId?: string }>;
-}) {
+}>) {
   const { objekt_id, doc_id } = await params;
   const { documentId } = await searchParams;
 
@@ -22,10 +22,16 @@ export default async function ResultLocalPreview({
   if (documentId) {
     const doc = await getDocumentById(documentId);
     if (doc) {
-      const supabase = await supabaseServer();
-      const { data } = await supabase.storage
+      const supabase = supabaseServiceRole();
+      const { data, error } = await supabase.storage
         .from("documents")
         .createSignedUrl(doc.document_url, 3600);
+      if (error) {
+        console.error("[Preview] createSignedUrl failed:", error.message, {
+          documentId,
+          path: doc.document_url,
+        });
+      }
       pdfUrl = data?.signedUrl ?? null;
     }
   }

--- a/src/app/api/heating-bill/document-url/[documentId]/route.ts
+++ b/src/app/api/heating-bill/document-url/[documentId]/route.ts
@@ -3,6 +3,7 @@ import database from "@/db";
 import { documents } from "@/db/drizzle/schema";
 import { eq } from "drizzle-orm";
 import { supabaseServer } from "@/utils/supabase/server";
+import { supabaseServiceRole } from "@/utils/supabase/serviceRole";
 
 /**
  * GET /api/heating-bill/document-url/[documentId]
@@ -53,7 +54,8 @@ export async function GET(
         }
 
         // Create a presigned URL from the stored document_url (storage path)
-        const { data: signedData, error: signedError } = await supabase.storage
+        const supabaseAdmin = supabaseServiceRole();
+        const { data: signedData, error: signedError } = await supabaseAdmin.storage
             .from("documents")
             .createSignedUrl(docRecord.document_url, 3600);
 
@@ -67,10 +69,16 @@ export async function GET(
         return NextResponse.json({ presignedUrl: signedData.signedUrl });
     } catch (error: unknown) {
         console.error("Document URL error:", error);
+        let details = "Unknown error";
+        if (error instanceof Error) {
+            details = error.message;
+        } else if (typeof error === "string") {
+            details = error;
+        }
         return NextResponse.json(
             {
                 error: "Failed to get document URL",
-                details: error instanceof Error ? error.message : String(error),
+                details,
             },
             { status: 500 },
         );

--- a/src/utils/supabase/serviceRole.ts
+++ b/src/utils/supabase/serviceRole.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+
+export function supabaseServiceRole() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("Missing Supabase service role configuration");
+  }
+
+  return createClient(url, serviceRoleKey);
+}


### PR DESCRIPTION
…t URL handling and add error logging# Fix PDF Preview "Kein Dokument gefunden"

## What Was Changed

- Added a server-only Supabase service-role helper at `src/utils/supabase/serviceRole.ts`.
- Updated all 4 Heizkostenabrechnung preview pages to generate document signed URLs with `supabaseServiceRole()` instead of `supabaseServer()`:
  - `src/app/(admin)/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/[local_id]/preview/page.tsx`
  - `src/app/(admin)/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/results/[local_id]/preview/page.tsx`
  - `src/app/(admin)/admin/[user_id]/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/preview/page.tsx`
  - `src/app/(admin)/heizkostenabrechnung/localauswahl/[objekt_id]/[local_id]/[doc_id]/results/preview/page.tsx`
- Added explicit error logging when `createSignedUrl()` fails in preview pages.
- Updated `src/app/api/heating-bill/document-url/[documentId]/route.ts` to:
  - Keep auth checks via `supabaseServer()`
  - Create signed URLs via `supabaseServiceRole()` to avoid storage RLS access mismatch.
- Applied minor lint-safe refactors in touched files (readonly props, simplified error detail handling).

## Why It Was Changed

- The preview page showed **"Kein Dokument gefunden"** because signed URL generation failed silently.
- Root cause: preview routes used session-bound anon client (`supabaseServer()`) for storage signed URL creation. For admin views across users, storage RLS blocked access because `auth.uid()` did not match object ownership.
- This caused `pdfUrl` to remain `null`, which triggered the empty-state UI even when a valid document existed.

## Impact on CI, Deployments, or Infrastructure

- **CI:** No pipeline or workflow changes required.
- **Deployments:** Standard application deploy only (code-level change in API/routes/utilities).
- **Infrastructure:** No schema migration, no bucket/policy change, no new external service.
- **Runtime requirement:** `SUPABASE_SERVICE_ROLE_KEY` must be present in the deployment environment (already used by other routes in this codebase).

## Required Follow-Up Actions

- Validate in staging/preview environment:
  - Open the affected admin preview URL and confirm PDF renders.
  - Test both `objektauswahl` and `localauswahl` preview flows.
  - Verify document download action still works through `/api/heating-bill/document-url/[documentId]`.
- Monitor logs for new `[Preview] createSignedUrl failed` entries after deploy.
- Optional hardening (future improvement): centralize signed URL creation behind a single API/helper to avoid duplicated route logic.

## Reviewer Notes / Test Focus

- Focus review on auth boundary correctness:
  - session auth remains required for route access
  - service role is used only for storage signed URL creation.
- Validate no regression in tenant/user-scoped document visibility from UI entry points.
## Summary

This PR adds download functionality for uploaded invoice documents in the Admin Heizkostenabrechnung Gesamtkosten view and hardens document resolution to avoid false 404s.

## What Was Changed

- Added a new API endpoint:
  - `GET /api/heating-bill/invoice-document-url`
  - File: `src/app/api/heating-bill/invoice-document-url/route.ts`
- The endpoint now resolves invoice files robustly using:
  - `relatedId`
  - `documentName`
  - `invoiceId` (fallback to `heating_invoices` metadata)
  - raw, sanitized, UUID-prefixed/stripped, and `%20`-decoded filename variants
- Added a download button in Admin Gesamtkosten invoice rows:
  - File: `src/components/Admin/Docs/CostTypes/Admin/AdminCostTypeHeatObjektauswahlItem.tsx`
  - Uses `Download` icon and calls the new API route
  - Sends `relatedId`, `documentName`, and `invoiceId`
  - Opens signed URL in a new tab
  - Includes loading/disabled state and toast error handling

## Why It Was Changed

- Uploaded invoice documents were visible but not downloadable in Admin Gesamtkosten.
- Initial implementation hit real-world 404s due to filename/storage-path mismatches (sanitized names, UUID-prefixed names, and encoded spaces).
- The updated resolution logic ensures reliable downloads across existing and legacy naming patterns, reducing reviewer/user confusion and support churn.

## Impact on CI, Deployments, and Infrastructure

- **CI:** No new dependencies; TypeScript/lint scope unchanged beyond modified files.
- **Deployment:** Requires standard web deployment only (new route + UI change).
- **Infrastructure:** No schema changes, migrations, bucket changes, or environment variable changes.
- **Runtime behavior:** New endpoint issues signed Supabase Storage URLs for matched documents.

## Follow-Up Actions

- Verify in staging with multiple filename variants:
  - plain names
  - names containing spaces/parentheses
  - UUID-prefixed names
- Optional cleanup (non-blocking):
  - Consolidate filename conventions at upload time to reduce future matching complexity.
  - Add integration test coverage for `invoice-document-url` resolution edge cases.

## Test Plan

- Open Admin route:
  - `/admin/[user_id]/heizkostenabrechnung/objektauswahl/[objekt_id]/[doc_id]/[path_slug]/gesamtkosten`
- For multiple invoice rows, click download:
  - Confirm `GET /api/heating-bill/invoice-document-url` returns `200`
  - Confirm signed URL opens and PDF downloads/displays
- Validate error behavior:
  - Missing/malformed params return `400`
  - Unauthenticated requests return `401`
  - Non-resolvable files return `404`

## Notes

- Current working tree also contains an unrelated `package.json` modification; this PR should include only the invoice download changes unless explicitly intended otherwise.