### PR TITLE
Add caching for document file sizes in DokumenteLayout component

### DIFF
--- a/src/components/Admin/Docs/DokumenteLayout/DokumenteLayout.tsx
+++ b/src/components/Admin/Docs/DokumenteLayout/DokumenteLayout.tsx
@@ -13,6 +13,7 @@ import { useDropzone } from "react-dropzone";
 import { useUploadDocuments } from "@/apiClient";
 
 const exo2 = Exo_2({ subsets: ["latin"] });
+const fileSizeCache = new Map<string, string>();
 
 interface Objekt {
   id: string;
@@ -163,6 +164,11 @@ export default function DokumenteLayout({ userId, objektsWithLocals, documents: 
     return documents.filter(doc => doc.objekt_id === selectedObjekt);
   }, [documents, selectedObjekt]);
 
+  const filteredDocumentSignature = useMemo(
+    () => filteredDocuments.map((doc) => `${doc.id}:${doc.document_url}`).join("|"),
+    [filteredDocuments]
+  );
+
   // Group documents by type into folders
   const documentFolders = useMemo(() => {
     const grouped = filteredDocuments.reduce((acc, doc) => {
@@ -211,19 +217,58 @@ export default function DokumenteLayout({ userId, objektsWithLocals, documents: 
   };
 
   useEffect(() => {
+    if (!filteredDocuments || filteredDocuments.length === 0) return;
+
+    let cancelled = false;
+
     const fetchSizes = async () => {
-      if (filteredDocuments && filteredDocuments.length > 0) {
-        for (const doc of filteredDocuments) {
-          const size = await getDocumentFileSize(doc.document_url);
-          setFileSizes((prev: Record<string, string>) => ({
-            ...prev,
-            [doc.id]: size
-          }));
+      const docsToFetch: DocumentMetadata[] = [];
+      const cachedSizes: Record<string, string> = {};
+
+      for (const doc of filteredDocuments) {
+        const cachedSize = fileSizeCache.get(doc.id);
+        if (cachedSize === undefined) {
+          docsToFetch.push(doc);
+        } else {
+          cachedSizes[doc.id] = cachedSize;
         }
       }
+
+      if (Object.keys(cachedSizes).length > 0) {
+        setFileSizes((prev) => ({
+          ...prev,
+          ...cachedSizes,
+        }));
+      }
+
+      if (docsToFetch.length === 0) return;
+
+      const nextSizes: Record<string, string> = {};
+
+      for (const doc of docsToFetch) {
+        if (cancelled) return;
+        const size = await getDocumentFileSize(doc.document_url);
+        fileSizeCache.set(doc.id, size);
+        nextSizes[doc.id] = size;
+      }
+
+      if (cancelled || Object.keys(nextSizes).length === 0) return;
+
+      setFileSizes((prev) => ({
+        ...prev,
+        ...nextSizes,
+      }));
     };
-    fetchSizes();
-  }, [filteredDocuments, getDocumentFileSize]);
+
+    void fetchSizes();
+
+    return () => {
+      cancelled = true;
+    };
+    // `filteredDocuments` reference is unstable across server payloads.
+    // Track a stable signature to avoid redundant storage list fetches.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filteredDocumentSignature]);
 
   const handleDownload = async (document: DocumentMetadata) => {
     try {


### PR DESCRIPTION
## Summary

This PR fixes redundant Supabase Storage list requests on the landlord documents route (`/dokumente`), including the case where deleting a document triggers a refresh and re-fetches all remaining file sizes.

## What Was Changed

- Updated file-size loading in `src/components/Admin/Docs/DokumenteLayout/DokumenteLayout.tsx`.
- Stabilized the file-size effect trigger with a deterministic signature derived from the currently visible documents.
- Changed file-size updates from per-document state writes to batched updates to reduce re-render churn.
- Added effect cancellation handling to avoid stale async updates during route transitions/refresh.
- Added a module-level `fileSizeCache` (`Map<string, string>`) so known sizes survive component remounts during `router.refresh()`.
- Updated fetch behavior to:
  - hydrate state from cache first
  - fetch only missing sizes
  - persist fresh results to both cache and local state

## Why It Was Changed

- The route was issuing repeated `POST /storage/v1/object/list/documents` calls.
- Root causes were repeated effect execution patterns and non-persistent in-memory state across refresh/remount scenarios.
- After document deletion, `router.refresh()` could remount the component and reset `fileSizes`, causing all remaining sizes to be fetched again.
- This increased request volume, slowed perceived responsiveness, and added noise during debugging/review.

## Impact on CI, Deployments, and Infrastructure

- **CI:** No pipeline/workflow/config changes.
- **Deployment:** Standard application deployment only.
- **Infrastructure:** No DB schema changes, no migrations, no bucket/policy changes, no new external services.
- **Runtime impact:** Reduced redundant Supabase Storage list calls from the `/dokumente` UI flow.

## Required Follow-Up Actions

- Validate in staging/local DevTools network tab:
  - loading `/dokumente` does not continuously fire `storage/v1/object/list/documents`
  - deleting a document does not re-fetch all remaining file sizes
  - toggling filters/navigation still shows correct sizes and document state
- Optional improvement (future): persist document size metadata at upload time to avoid runtime storage list lookups in the UI path.

## Test Notes

- Manual regression test on landlord dashboard `/dokumente`:
  - open page and inspect requests
  - delete a document
  - verify list updates correctly and storage list requests remain bounded